### PR TITLE
feat: use release-drafter to compile PRs merged into main since last release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,17 +15,17 @@ jobs:
         
       - uses: actions/setup-node@v5
         with:
-          node-version: 16
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Get version from release tag
         id: get_version
         run: |
           release_tag="${{ github.event.release.tag_name }}"
-          version_without_v=$(echo $release_tag | sed 's/^v//')
+          version=$(echo $release_tag | sed 's/^v//')
           echo "Release tag: $release_tag"
-          echo "Version: $version_without_v"
-          echo "Version=$version_without_v" >> $GITHUB_OUTPUT
+          echo "Version: $version"
+          echo "Version=$version" >> $GITHUB_OUTPUT
 
       - name: Update package.json version for publishing
         run: npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 16
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Get version from release tag
+        id: get_version
+        run: |
+          release_tag="${{ github.event.release.tag_name }}"
+          version_without_v=$(echo $release_tag | sed 's/^v//')
+          echo "Release tag: $release_tag"
+          echo "Version: $version_without_v"
+          echo "Version=$version_without_v" >> $GITHUB_OUTPUT
+
+      - name: Update package.json version for publishing
+        run: npm version ${{ steps.get_version.outputs.version }} --no-git-tag-version
+          
+      - run: npm ci
+        
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,9 @@ We use [release-drafter](https://github.com/release-drafter/release-drafter) to 
 ### Version Increment Guidelines
 
 PR labels determine version increment:
+
 - `major` label: Increments major version
-- `minor` label: Increments minor version  
+- `minor` label: Increments minor version
 - `patch` label: Increments patch version
 
 ### Manual Release Publishing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,7 @@ PR labels determine version increment:
 - `major` label: Increments major version
 - `minor` label: Increments minor version
 - `patch` label: Increments patch version
+- if no label is present: Increments patch version
 
 ### Manual Release Publishing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,30 @@ npx ~/repos/provectus/awos/index.js --force-overwrite
 3. ✅ Ensure all files are committed
 4. ✅ Write a clear PR description
 
+## Release Process
+
+### Automated Release Drafting
+
+We use [release-drafter](https://github.com/release-drafter/release-drafter) to automatically compile pull requests into release notes.
+
+### Version Increment Guidelines
+
+PR labels determine version increment:
+- `major` label: Increments major version
+- `minor` label: Increments minor version  
+- `patch` label: Increments patch version
+
+### Manual Release Publishing
+
+To publish a release:
+
+1. Navigate to GitHub Releases page
+2. Edit the draft release
+3. Optional: Update changelog
+4. Click "Publish release"
+
+**Important**: The npm package is published only after manually publishing the release.
+
 ---
 
 Thank you for contributing to AWOS! 🚀


### PR DESCRIPTION
Once the release is manually published only then npm package gets published as well.

After you're ready to publish a release:

1. navigate to https://github.com/provectus/awos/releases
2. click edit on the draft release
3. update or edit contents, changelog (optional)
4. click publish release (set as latest release is checked by default)

**Important notes:**
- if you don't label PRs - they are treated as patches
- the following PR labels are needed to automate version resolving: `patch`, `minor`, `major`

Action used: https://github.com/release-drafter/release-drafter
