### PR TITLE
Add AskUserQuestion instruction to command wrappers

### DIFF
--- a/claude/commands/architecture.md
+++ b/claude/commands/architecture.md
@@ -2,4 +2,6 @@
 description: Defines the System Architecture — stack, DBs, infra.
 ---
 
+Use `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
 Refer to the instructions located in this file: .awos/commands/architecture.md

--- a/claude/commands/implement.md
+++ b/claude/commands/implement.md
@@ -2,4 +2,6 @@
 description: Runs tasks — delegates coding to sub-agents, tracks progress.
 ---
 
+Use `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
 Refer to the instructions located in this file: .awos/commands/implement.md

--- a/claude/commands/product.md
+++ b/claude/commands/product.md
@@ -2,4 +2,6 @@
 description: Defines the Product — what, why, and for who.
 ---
 
+Use `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
 Refer to the instructions located in this file: .awos/commands/product.md

--- a/claude/commands/roadmap.md
+++ b/claude/commands/roadmap.md
@@ -2,4 +2,6 @@
 description: Builds the Product Roadmap — features and their order.
 ---
 
+Use `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
 Refer to the instructions located in this file: .awos/commands/roadmap.md

--- a/claude/commands/spec.md
+++ b/claude/commands/spec.md
@@ -2,4 +2,6 @@
 description: Creates the Functional Spec — what the feature does for the user.
 ---
 
+Use `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
 Refer to the instructions located in this file: .awos/commands/spec.md

--- a/claude/commands/tasks.md
+++ b/claude/commands/tasks.md
@@ -2,4 +2,6 @@
 description: Breaks the Tech Spec into a task list for engineers.
 ---
 
+Use `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
 Refer to the instructions located in this file: .awos/commands/tasks.md

--- a/claude/commands/tech.md
+++ b/claude/commands/tech.md
@@ -2,4 +2,6 @@
 description: Creates the Technical Spec — how the feature will be built.
 ---
 
+Use `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
 Refer to the instructions located in this file: .awos/commands/tech.md

--- a/claude/commands/verify.md
+++ b/claude/commands/verify.md
@@ -2,4 +2,6 @@
 description: Verifies spec completion — checks acceptance criteria, marks Status as Completed.
 ---
 
+Use `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
 Refer to the instructions located in this file: .awos/commands/verify.md


### PR DESCRIPTION
## Summary

Adds instruction to all Claude command wrappers to use the `AskUserQuestion` tool for multiple-choice questions.

## Changes

All 8 files in `claude/commands/` now include:

```markdown
Use `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
```

This ensures users get clickable options instead of numbered lists when commands ask them to choose (e.g., selecting a spec, choosing a section).

## Files Modified
- `claude/commands/product.md`
- `claude/commands/roadmap.md`
- `claude/commands/architecture.md`
- `claude/commands/spec.md`
- `claude/commands/tech.md`
- `claude/commands/tasks.md`
- `claude/commands/implement.md`
- `claude/commands/verify.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)