### PR TITLE
feat: migrate npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -8,16 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Get latest release tag and increment patch version
@@ -42,9 +43,7 @@ jobs:
         run: npm install
 
       - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: npm publish --access public
 
       - name: Create git tag
         run: |
@@ -52,9 +51,8 @@ jobs:
           git push origin ${{ steps.get_version.outputs.new_tag }}
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.new_tag }}
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -32,7 +33,4 @@ jobs:
           
       - run: npm install
         
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+      - run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@provectusinc/awos",
   "version": "0.0.0-develop",
   "description": "This framework outlines a structured approach to leveraging Large Language Models (LLMs) for high-quality code generation, moving beyond basic prompting to a spec-driven development methodology.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/provectus/awos.git"
+  },
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- Add id-token: write permission for OIDC authentication
- Remove NODE_AUTH_TOKEN secret dependency
- Add repository field to package.json
- Upgrade manual-release.yml actions to v4 and Node 22
- Upgrade softprops/action-gh-release to v2