### PR TITLE
fix: use TEMP_NPM_TOKEN for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,5 @@ jobs:
       - run: npm install
         
       - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.TEMP_NPM_TOKEN }}


### PR DESCRIPTION
OIDC trusted publishing not working as expected. Using granular access token (30-day) as temporary solution.