### PR TITLE
Update /awos:tech by clarifying the expected level of detail and adding explicit guidance

### DIFF
--- a/commands/tech.md
+++ b/commands/tech.md
@@ -58,6 +58,12 @@ Follow this process precisely.
 
 2.  **Detailed Implementation (Assume but Verify):**
     - Work through the sections of the template (System Changes, API, etc.).
+    - **LEVEL OF DETAIL:** Describe structures and contracts, not implementations. The spec should be reviewable and not go stale.
+      - For schemas: list table names, key columns, and relationships in a table format (no full DDL/ORM code)
+      - For APIs: specify endpoints, methods, and payload shapes (no handler code)
+      - For configs: list required env vars and their purpose (no full file contents)
+      - For files: specify paths and responsibilities (no full implementations)
+      - Reference official docs for exact syntax/requirements rather than duplicating them
     - **CRITICAL BEHAVIOR:** For each section, you must propose a specific implementation detail based on the architecture, state it as an assumption, and ask for approval.
     - Example: "For the database, the functional spec implies we need to store the image location. I'll **assume** we should add a new `avatar_url` (TEXT) column to the `users` table. **Is that assumption correct?**"
     - Example: "For the API, I'll propose a `POST /api/v1/users/me/avatar` endpoint that accepts a multipart/form-data request. **Does that fit the requirements?**"

--- a/templates/technical-considerations-template.md
+++ b/templates/technical-considerations-template.md
@@ -1,3 +1,19 @@
+<!--
+This document describes HOW to build the feature at an architectural level.
+It is NOT a copy-paste implementation guide.
+
+DO:
+- Describe data models (table names, key columns, relationships)
+- Describe API contracts (endpoints, request/response shapes)
+- Reference file paths where code will live
+- Note critical configuration requirements
+
+DON'T:
+- Include full code implementations
+- Write complete schema definitions
+- Provide copy-paste config files
+-->
+
 # Technical Specification: [Name of the Change]
 
 - **Functional Specification:** [Link to the approved Functional Spec document]


### PR DESCRIPTION
This pull request improves the technical specification process by clarifying the expected level of detail and adding explicit guidance to both the process documentation and the technical considerations template. The changes help ensure that specs are reviewable, avoid unnecessary implementation details, and stay maintainable.

Documentation and process improvements:

* Updated `commands/tech.md` to specify the appropriate level of detail for technical specs, including guidelines for describing schemas, APIs, configs, and file responsibilities, and emphasizing referencing official documentation over duplicating syntax.
* Added a detailed comment block to the top of `templates/technical-considerations-template.md` outlining what should and should not be included in technical specification documents, reinforcing the guidance from the process documentation.