### PR TITLE
feat(tasks): require verification scenarios for all vertical slices

### DIFF
--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -66,10 +66,11 @@ Follow this process precisely.
         - Task intent
         - Tech stack identified in technical-considerations.md
       - Append the subagent assignment using format: `**[Agent: agent-name]**` at the end of the sub-task description
-      - Use `general-purpose` agent when no specialist clearly matches the task
+      - Use `general-purpose` agent when no specialist clearly matches the task — but **track these assignments** for the Recommendations table
   5.  Next, identify the second-smallest piece of value that builds on the first. This is **Slice 2**.
   6.  Create a high-level checklist item and its sub-tasks with subagent assignments.
   7.  Repeat this process until all requirements from the specification are covered.
+  8.  For each slice's verification sub-task, identify required MCPs/services (browser MCP, curl, database access, etc.) and note any that may be missing.
 
 - **Example of applying the rule for "User Profile Picture Upload":**
   - **Bad, Horizontal Tasks (DO NOT DO THIS):**
@@ -91,9 +92,15 @@ Follow this process precisely.
 - Present the complete, vertically sliced task list with subagent assignments to the user.
 - Ask for feedback: "Here is a proposed task list, broken down into runnable, incremental slices with subagent assignments. Does this sequence, level of detail, and subagent assignments look correct? We can adjust, split, merge tasks, or reassign subagents as needed."
 - Allow the user to request changes until they are satisfied.
+- If any tasks were assigned to `general-purpose` (because no specialist exists) or verification cannot be performed (missing MCPs/services), present a table:
 
-## Step 5: File Generation
+  | Task/Slice            | Issue                                                    | Recommendation                                       |
+  | --------------------- | -------------------------------------------------------- | ---------------------------------------------------- |
+  | Slice 2: Sub-task 3   | Assigned to `general-purpose` — no TypeScript specialist | Install `typescript-pro` agent for proper delegation |
+  | Slice 3: Verification | Browser MCP not available                                | Install browser MCP to enable UI verification        |
+
+## Step 6: File Generation
 
 1.  **Identify Path:** The output path is the `tasks.md` file inside the directory you identified in Step 1.
 2.  **Save File:** Once the user approves the draft, write the final task list into this file.
-3.  **Conclude:** Announce the completion and the file's location: "The task list has been created. You can find it at `context/spec/[directory-name]/tasks.md`. Let’s get to work! Execute the next task with `/awos:implement` when you're ready."
+3.  **Conclude:** Announce the completion and the file's location: "The task list has been created. You can find it at `context/spec/[directory-name]/tasks.md`. Let's get to work! Execute the next task with `/awos:implement` when you're ready."

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -22,6 +22,7 @@ Verify a specification's implementation against its acceptance criteria. For eac
   - `technical-considerations.md`
   - `tasks.md`
 - **Output:** Updated spec files with verified criteria marked and Status set to `Completed`
+- **Output (Optional):** Suggested `/awos:*` commands to run if product context documents need updates
 
 ---
 
@@ -54,7 +55,25 @@ If all criteria verified:
 2. Change `technical-considerations.md` Status to `Completed`
 3. Mark roadmap item as `[x]` in `context/product/roadmap.md`
 
-### Step 5: Announce
+### Step 5: Review Product Context
+
+Check if `context/product/` documents need updates based on what was learned during implementation:
+
+1. **Read product documents:** `architecture.md`, `product-definition.md`, `roadmap.md`
+2. **Compare against implementation:** Does the actual implementation match what's documented?
+3. **If discrepancies found:** Tell the user which command to run with a specific prompt:
+   - **product-definition.md outdated:** `/awos:product <prompt describing what changed>`
+   - **architecture.md outdated:** `/awos:architecture <prompt describing what changed>`
+   - **roadmap.md outdated:** `/awos:roadmap <prompt describing what changed>`
+
+4. **Format suggestion as actionable command**, e.g.:
+   ```
+   Run: /awos:architecture Add Redis caching layer that was implemented for session storage
+   ```
+
+**Skip this step** if no significant implementation learnings or deviations occurred.
+
+### Step 6: Announce
 
 - Success: "Spec verified and marked complete. All acceptance criteria met."
 - Failure: "Verification failed. The following criteria are not met: [list]"


### PR DESCRIPTION
## Summary
- Require every vertical slice to include test/verification scenarios that agents must complete
- Add dependency checks (MCPs, services) before verification can proceed
- Surface gaps in agent/tooling coverage via a Recommendations table
- Enhance `/verify` command to suggest product doc updates post-implementation

## Motivation
Previously, task slices could be marked complete without actual verification. This led to untested increments and late-stage failures. This change enforces "definition of done" at the slice level.

## Changes
- **tasks.md**: Slices must include verification sub-tasks using real tools (browser MCP, curl, shell)
- **tasks.md**: Track `general-purpose` agent assignments and missing MCPs for user awareness
- **verify.md**: After verification, check if product docs need updates and suggest commands

## Test plan
- [ ] Run `/awos:tasks` on an existing spec and confirm verification sub-tasks are generated
- [ ] Confirm Recommendations table appears when MCPs are missing
- [ ] Run `/awos:verify` and confirm product doc suggestions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)