### PR TITLE
feat(verify): suggest product doc updates after spec verification

### DIFF
--- a/commands/verify.md
+++ b/commands/verify.md
@@ -22,6 +22,7 @@ Verify a specification's implementation against its acceptance criteria. For eac
   - `technical-considerations.md`
   - `tasks.md`
 - **Output:** Updated spec files with verified criteria marked and Status set to `Completed`
+- **Output (Optional):** Suggested `/awos:*` commands to run if product context documents need updates
 
 ---
 
@@ -54,7 +55,25 @@ If all criteria verified:
 2. Change `technical-considerations.md` Status to `Completed`
 3. Mark roadmap item as `[x]` in `context/product/roadmap.md`
 
-### Step 5: Announce
+### Step 5: Review Product Context
+
+Check if `context/product/` documents need updates based on what was learned during implementation:
+
+1. **Read product documents:** `architecture.md`, `product-definition.md`, `roadmap.md`
+2. **Compare against implementation:** Does the actual implementation match what's documented?
+3. **If discrepancies found:** Tell the user which command to run with a specific prompt:
+   - **product-definition.md outdated:** `/awos:product <prompt describing what changed>`
+   - **architecture.md outdated:** `/awos:architecture <prompt describing what changed>`
+   - **roadmap.md outdated:** `/awos:roadmap <prompt describing what changed>`
+
+4. **Format suggestion as actionable command**, e.g.:
+   ```
+   Run: /awos:architecture Add Redis caching layer that was implemented for session storage
+   ```
+
+**Skip this step** if no significant implementation learnings or deviations occurred.
+
+### Step 6: Announce
 
 - Success: "Spec verified and marked complete. All acceptance criteria met."
 - Failure: "Verification failed. The following criteria are not met: [list]"


### PR DESCRIPTION
## Summary
After completing spec verification, check if product context documents need updates based on implementation learnings and suggest actionable `/awos:*` commands.

## Motivation
During implementation, teams often discover architectural changes or product refinements that should be documented. This enhancement ensures those learnings are captured by prompting users to update product docs when relevant.

## Changes
- Add Step 5 "Review Product Context" to verification flow
- Check `architecture.md`, `product-definition.md`, `roadmap.md` against actual implementation
- Suggest specific `/awos:*` commands with prompts when discrepancies are found

## Test plan
- [ ] Run `/awos:verify` on a completed spec
- [ ] Confirm product doc review step executes
- [ ] Verify actionable command suggestions are formatted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)