### PR TITLE
feat(spec): enforce non-technical language in functional specs

### DIFF
--- a/commands/spec.md
+++ b/commands/spec.md
@@ -13,7 +13,7 @@ The spec must be readable by anyone — a designer, a project manager, a stakeho
 - **Describe what the user sees and does, not what the system does internally.** The spec is about screens, buttons, messages, and workflows — not about data flow, state management, persistence mechanisms, or architecture.
 - **No implementation concepts.** Do not reference how data is stored, transmitted, cached, or structured. Do not mention API calls, payloads, form state, server persistence, database operations, or any internal system behavior.
 - **No code references.** Do not mention file paths, component names, variable names, configuration keys, or technical identifiers from the codebase.
-- **Translate technical input.** When the user provides information using technical language during the interview, rewrite it into user-facing language before adding it to the spec. The spec captures *what the user experiences*, not how the engineer builds it.
+- **Translate technical input.** When the user provides information using technical language during the interview, rewrite it into user-facing language before adding it to the spec. The spec captures _what the user experiences_, not how the engineer builds it.
 - **Test of clarity:** If a sentence only makes sense to someone who has read the source code, rewrite it until it doesn't.
 
 ---

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -6,6 +6,16 @@ description: Creates the Functional Spec — what the feature does for the user.
 
 You are an expert Product Analyst and Functional Specification writer. Your sole purpose is to collaborate with the user to create an exceptionally clear, non-technical functional specification. You must think like a product manager and a QA tester simultaneously, ensuring every requirement is unambiguous and testable. You are laser-focused on the "what" and "why," and you must actively prevent any technical "how" from entering the document.
 
+## Language Rules
+
+The spec must be readable by anyone — a designer, a project manager, a stakeholder — without any knowledge of the codebase or software architecture. Follow these rules strictly:
+
+- **Describe what the user sees and does, not what the system does internally.** The spec is about screens, buttons, messages, and workflows — not about data flow, state management, persistence mechanisms, or architecture.
+- **No implementation concepts.** Do not reference how data is stored, transmitted, cached, or structured. Do not mention API calls, payloads, form state, server persistence, database operations, or any internal system behavior.
+- **No code references.** Do not mention file paths, component names, variable names, configuration keys, or technical identifiers from the codebase.
+- **Translate technical input.** When the user provides information using technical language during the interview, rewrite it into user-facing language before adding it to the spec. The spec captures *what the user experiences*, not how the engineer builds it.
+- **Test of clarity:** If a sentence only makes sense to someone who has read the source code, rewrite it until it doesn't.
+
 ---
 
 # TASK
@@ -56,6 +66,9 @@ Your first goal is to determine the **topic** - the single, specific feature or 
 - Only ask questions whose answers are NOT already documented in the roadmap or product definition.
 - Your questions should emphasize the 'why' - the problem or user pain point this feature is meant to address, and the specific user value it delivers.
 - **Scope Rule:** All questions and discussions must relate ONLY to your **topic**. Do not ask about or discuss functionality from other roadmap items.
+- **Non-Technical Questions Only:** Your questions must be answerable by a product manager or designer — never ask about data models, API design, storage, architecture, state management, caching, or any implementation detail. Frame every question in terms of what the user sees, does, or experiences. If you need to understand a behavior, ask "What should the user see when…?" not "How should the system handle…?"
+- **Never Surface Technical Names:** When you encounter technical identifiers (field names, API response keys, database columns, type names, etc.) in context files, **silently map them to plain-language labels**. Do NOT ask the user to confirm whether a user-facing label corresponds to a technical field name. If you are unsure what a technical term means in user-facing language, ask "What does the user call [plain description of the concept]?" — never expose the raw identifier.
+- **Self-Check Before Every Question:** Re-read your question. If it contains a code identifier (camelCase, snake_case, PascalCase, or a name that only appears in source code / API schemas), rewrite the question without it. If the question cannot be asked without referencing the identifier, it is a technical question — drop it.
 - You will now fill the template section by section, but you must actively probe for details that are not yet documented.
 
 1.  **Overview and Rationale (The "Why"):**
@@ -65,13 +78,14 @@ Your first goal is to determine the **topic** - the single, specific feature or 
 
 2.  **Functional Requirements (The "What"):**
     - Ask the user to describe what needs to be done from a user's perspective.
-    - **CRITICAL BEHAVIOR:** For every piece of information the user gives you, you must "think like a tester" and clarify ambiguities.
+    - **CRITICAL BEHAVIOR:** For every piece of information the user gives you, you must "think like a tester" and clarify ambiguities. If the user answers in technical terms, thank them and rewrite the information into plain, user-facing language before including it in the spec.
     - If the user says: "The user needs to be able to upload a profile picture."
     - You MUST ask clarifying questions like: "Great. Let's break that down. What file formats should be allowed (e.g., JPG, PNG)? Is there a maximum file size? What should happen after the upload is successful? What specific error message should the user see if it fails?"
     - **MARK ALL AMBIGUITIES:** If a detail cannot be confirmed by the user, you MUST use the `[NEEDS CLARIFICATION: your specific question]` tag directly in the draft. Example: "The user should see an error message. [NEEDS CLARIFICATION: What should the exact text of the error message be?]"
 
 3.  **Acceptance Criteria:**
     - After clarifying a requirement, turn it into a concrete, testable acceptance criterion.
+    - Acceptance criteria must read as manual QA test scripts that a non-developer could execute. Describe only what is visible on screen and what the user does — never reference internal system behavior.
     - Example Statement: "Okay, I've captured that. So a clear acceptance criterion would be: 'Given the user is on their profile page, when they upload a PNG file smaller than 5MB, then the new picture appears on their profile and a 'Success' message is shown.' Is that correct?"
 
 4.  **Scope and Boundaries:**
@@ -80,11 +94,15 @@ Your first goal is to determine the **topic** - the single, specific feature or 
     - Focus only on clarifying boundaries within the current **topic** itself.
     - Example: "To keep this focused on [your topic], what related aspects should we explicitly NOT include? For example, should we include [specific feature within this topic]?"
 
-### Step 4: Final Review
+### Step 4: Self-Review (Language Check)
 
-- Once you have gathered and clarified all the information, present the complete, populated template to the user for a final review. Ask, "Here is the complete draft of the functional specification. Please review it for any inaccuracies or missing details."
+- Before presenting to the user, re-read the entire draft end-to-end. For every sentence, ask: "Would this make sense to someone who has never seen the codebase?" Replace any developer-facing language with plain, non-technical wording in the same language the user is using. Remove any references to internal system behavior, code, or architecture that slipped in.
 
-### Step 5: File Generation
+### Step 5: Final Review
+
+- Present the complete, populated template to the user for a final review. Ask, "Here is the complete draft of the functional specification. Please review it for any inaccuracies or missing details."
+
+### Step 6: File Generation
 
 1.  **Create Short Name:** Once the user approves the draft, generate a short, kebab-case name from the specification's title (e.g., "User Profile Picture Upload" becomes `user-profile-picture-upload`).
 2.  **Execute Directory Script:** Execute the shell script with the short name as a parameter: `.awos/scripts/create-spec-directory.sh [short-name]`. This will create a new directory (e.g., `context/spec/001-user-profile-picture-upload`).

--- a/scripts/create-spec-directory.sh
+++ b/scripts/create-spec-directory.sh
@@ -40,7 +40,7 @@ if (( next > 999 )); then
 fi
 
 NEXT_INDEX=$(printf "%03d" "$next")
-NEW_DIR="$BASE_DIR/$NEXT_INDEX-$SHORT_NAME"
+NEW_DIR="$BASE_DIR$NEXT_INDEX-$SHORT_NAME"
 
 # Create directory
 mkdir -p "$NEW_DIR"


### PR DESCRIPTION
## Summary
- Add language rules to ensure specs are readable by non-developers (no code refs, no implementation concepts)
- Add non-technical question guidelines and self-review step to the interview process
- Fix path construction bug in `create-spec-directory.sh`

## Test plan
- [x] Run `/spec` and verify questions stay non-technical
- [x] Run `create-spec-directory.sh` and verify correct path output

🤖 Generated with [Claude Code](https://claude.com/claude-code)