### PR TITLE
fix(ci): pin publish workflow to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,14 +27,10 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          # Pinned to 22.21 — Node 22.22.2 ships a broken bundled npm that
-          # crashes `npm install -g npm@latest` with a missing `promise-retry`
-          # module. See actions/runner-images#13883.
-          node-version: '22.21'
+          # Node 24 ships with npm 11.5.1+, which already supports OIDC
+          # trusted publishing — no global npm upgrade needed.
+          node-version: '24'
           # DO NOT use registry-url - it interferes with OIDC
-
-      - name: Upgrade npm to 11.x (required for OIDC)
-        run: npm install -g npm@latest
 
       - name: Configure npm registry
         run: npm config set registry https://registry.npmjs.org/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,10 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          # Pinned to 22.21 — Node 22.22.2 ships a broken bundled npm that
+          # crashes `npm install -g npm@latest` with a missing `promise-retry`
+          # module. See actions/runner-images#13883.
+          node-version: '22.21'
           # DO NOT use registry-url - it interferes with OIDC
 
       - name: Upgrade npm to 11.x (required for OIDC)


### PR DESCRIPTION
## Summary
- Switches `setup-node` in the publish workflow from Node 22 to **Node 24**.
- Removes the `npm install -g npm@latest` step — Node 24 ships with npm 11.5.1+ which already supports OIDC trusted publishing, so the global upgrade is no longer needed.
- Sidesteps the broken bundled npm in Node 22.22.2 (actions/runner-images#13883) completely, rather than pinning to 22.21 as a workaround.
- Aligns with GitHub's plan to default runners to Node 24 on 2026-06-02 and remove Node 20 on 2026-09-16.

## Test plan
- [ ] Trigger `Publish Package` via `workflow_dispatch` with a prerelease version and confirm `npm publish --provenance` succeeds under OIDC on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)