### PR TITLE
chore(plugin): bump awos plugin to 2.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "AWOS plugins for AI-native development workflows",
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "plugins": [
     {
       "name": "awos",
       "source": "./plugins/awos",
       "description": "Comprehensive code quality audit framework with auto-discoverable dimensions",
-      "version": "2.0.0"
+      "version": "2.1.0"
     }
   ]
 }

--- a/plugins/awos/.claude-plugin/plugin.json
+++ b/plugins/awos/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "awos",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "AWOS code quality audit framework",
   "author": {
     "name": "Provectus"


### PR DESCRIPTION
## Summary
- Bumps the in-repo awos Claude Code plugin from 2.0.0 → 2.1.0.
- Updates all three version strings in lockstep: `plugins/awos/.claude-plugin/plugin.json`, marketplace `metadata.version`, and marketplace plugin entry `version`.
- Minor bump reflects backward-compatible additions since 2.0.0 (e.g. Quality Assurance dimension in #110).

Independent of the npm package version (`@provectusinc/awos`), which is driven by Git tags.

## Test plan
- [x] `jq` parses both JSON files successfully
- [x] All three version fields read back as `2.1.0`
- [ ] Marketplace consumers pick up the new version on next pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)