### PR TITLE
feat(spec): add AC Given-When-Then shape, clarify-first, propagate-to-requirement rules

### DIFF
--- a/commands/spec.md
+++ b/commands/spec.md
@@ -92,6 +92,9 @@ Your first goal is to determine the **topic** - the single, specific feature or 
 3.  **Acceptance Criteria:**
     - After clarifying a requirement, turn it into a concrete, testable acceptance criterion.
     - Acceptance criteria must read as manual QA test scripts that a non-developer could execute. Describe only what is visible on screen and what the user does — never reference internal system behavior.
+    - Each acceptance criterion should follow the same three-part shape as the example below: a precondition (Given), a user action (When), and a visible outcome (Then). State the precondition explicitly even when it is obvious from context.
+    - If information is missing, ask clarifying questions before writing acceptance criteria.
+    - If a clarifying answer reveals a constraint or detail that belongs to the parent requirement (not just the acceptance criterion), update the requirement statement in §Functional Requirements before continuing. The requirement and its acceptance criteria must agree on level of detail.
     - Example Statement: "Okay, I've captured that. So a clear acceptance criterion would be: 'Given the user is on their profile page, when they upload a PNG file smaller than 5MB, then the new picture appears on their profile and a 'Success' message is shown.' Is that correct?"
 
 4.  **Scope and Boundaries:**

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -87,13 +87,13 @@ Your first goal is to determine the **topic** - the single, specific feature or 
     - For every piece of information the user gives you, think like a tester and clarify ambiguities. If the user answers in technical terms, rewrite the information into plain, user-facing language before including it in the spec.
     - If the user says: "The user needs to be able to upload a profile picture."
     - You MUST ask clarifying questions like: "Great. Let's break that down. What file formats should be allowed (e.g., JPG, PNG)? Is there a maximum file size? What should happen after the upload is successful? What specific error message should the user see if it fails?"
-    - Mark every unresolved detail with `[NEEDS CLARIFICATION: your specific question]` directly in the draft. Example: "The user should see an error message. [NEEDS CLARIFICATION: What should the exact text of the error message be?]"
+    - If information is missing, mark every unresolved detail with `[NEEDS CLARIFICATION: your specific question]` directly in the draft. Example: "The user should see an error message. [NEEDS CLARIFICATION: What should the exact text of the error message be?]"
 
 3.  **Acceptance Criteria:**
     - After clarifying a requirement, turn it into a concrete, testable acceptance criterion.
     - Acceptance criteria must read as manual QA test scripts that a non-developer could execute. Describe only what is visible on screen and what the user does — never reference internal system behavior.
-    - Each acceptance criterion should follow the same three-part shape as the example below: a precondition (Given), a user action (When), and a visible outcome (Then). State the precondition explicitly even when it is obvious from context.
-    - If information is missing, ask clarifying questions before writing acceptance criteria.
+    - Each acceptance criterion follows the same three-part shape as the example below: a precondition (Given), a user action (When), and a visible outcome (Then). Include Given only when the precondition affects the outcome.
+    - If any `[NEEDS CLARIFICATION: …]` markers remain on the parent requirement in §Functional Requirements, ask clarifying questions and resolve the markers before writing acceptance criteria.
     - If a clarifying answer reveals a constraint or detail that belongs to the parent requirement (not just the acceptance criterion), update the requirement statement in §Functional Requirements before continuing. The requirement and its acceptance criteria must agree on level of detail.
     - Example Statement: "Okay, I've captured that. So a clear acceptance criterion would be: 'Given the user is on their profile page, when they upload a PNG file smaller than 5MB, then the new picture appears on their profile and a 'Success' message is shown.' Is that correct?"
 


### PR DESCRIPTION
## Summary

Adds three rule anchors to `commands/spec.md` §Step 3.3 Acceptance Criteria.
No template change, no new files, no dependencies.

## What changes

`commands/spec.md` §Step 3.3 — three new bullets between the existing "manual QA test scripts" rule and the Example Statement:

1. **Three-part shape.** Each AC follows Given (precondition) + When (user action) + Then (visible outcome) — the same shape as the example, matching Gherkin/BDD convention.
2. **Clarify-first.** Ask clarifying questions if information is missing, before writing the AC.
3. **Propagate-to-requirement.** If a clarifying answer affects the parent requirement (not just the AC), update §Functional Requirements first.

## Why

### Claude Code prompting
- Explicit rules combined with examples produce more stable structured output than examples alone.
- The new rules use the same vocabulary as the existing example (Given/When/Then) — naming the shape strengthens the signal more than paraphrasing it.
- "Ask before guessing" reduces a documented failure mode where the model fills missing inputs with plausible details.
- "Name the destination" prevents the model from appending new facts only at the point of receipt instead of updating upstream sections.

## Risk and limitations
- **Applicability.** Works for behavioral specs and can be adapted for background or scheduled flows.
- **Trade-off.** Slightly longer prompts, but clearer and more testable acceptance criteria.
- **Scope.** Touches only `/awos:spec`. Downstream skills (`/awos:tech`, `/awos:tasks`, `/awos:implement`) are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated functional specification guidelines to require explicit marking of missing details with clarification markers in requirements sections.
  * Enhanced acceptance criteria guidance with Given/When/Then format for concrete, testable scenarios.
  * Clarified workflow for resolving clarification markers before finalizing acceptance criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/provectus/awos/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->