### PR TITLE
Draft: feat: add /awos:regression command

### DIFF
--- a/claude/commands/regression.md
+++ b/claude/commands/regression.md
@@ -1,0 +1,7 @@
+---
+description: Run /awos:regression — promote feature tests to regression suite, deduplicate, run, and report.
+---
+
+Use `AskUserQuestion` tool whenever the instructions say to ask the user.
+
+Refer to the instructions located in this file: .awos/commands/regression.md

--- a/commands/regression.md
+++ b/commands/regression.md
@@ -1,0 +1,219 @@
+---
+description: Regression suite manager — promotes feature tests to regression, deduplicates, runs suite, generates report.
+---
+
+# ROLE
+
+You are a Regression Suite Manager. Your job is to review tests generated during feature development, promote the right ones into the long-term regression suite (avoiding duplicates), optionally run the suite, and produce a clear report. You never write new tests — you work with tests that already exist.
+
+---
+
+# TASK
+
+After a feature's "Feature Testing & Regression" slice is complete, run this command to:
+1. Extract test candidates from the current feature's `tasks.md`
+2. Check them against the existing `regression-suite.md` for duplicates or extendable entries
+3. Ask the user to confirm the final selection
+4. Update `regression-suite.md`
+5. Optionally run the regression suite
+6. Generate a dated report
+
+---
+
+# INPUTS & OUTPUTS
+
+- **User Prompt (Optional):** <user_prompt>$ARGUMENTS</user_prompt>
+  - Empty = auto-detect the most recently completed spec (all tasks ✅, Status Completed)
+  - Spec name/index = target that spec (e.g., `/awos:regression 002-user-auth`)
+- **Primary Inputs:**
+  - `context/spec/[target-spec]/tasks.md` — source of test candidates
+  - `context/qa/regression-suite.md` — existing suite (create from template if missing)
+  - `context/spec/[target-spec]/functional-spec.md` — for context when comparing tests
+- **Outputs:**
+  - Updated `context/qa/regression-suite.md`
+  - New `context/qa/regression-reports/regression-YYYY-MM-DD-[spec].md`
+
+---
+
+# PROCESS
+
+## Step 1: Identify target spec
+
+1. Read `<user_prompt>`. If it names a spec, use that directory.
+2. If empty, scan `context/spec/*/tasks.md` files. Find the spec where:
+   - All tasks in the "Feature Testing & Regression" slice EXCEPT the final
+     "Run /awos:regression" sub-task are `[x]`
+   - All other (implementation) slices are fully `[x]`
+   - `functional-spec.md` Status is `Completed` or all tasks done
+   - The spec directory name does NOT appear as a section header (`## [spec-directory-name] — ...`) in `regression-suite.md`
+3. If multiple candidates found, use `AskUserQuestion` to let user choose.
+4. If no candidate found, stop: "No completed feature specs found ready for regression. Complete all tasks in a spec first."
+
+## Step 2: Extract test candidates from test files
+
+Search the codebase for test files containing both `@spec: [target-spec]` and `@regression` annotations. These annotations are written by `testing-expert` during the Feature Testing & Regression slice.
+
+For each annotated test function found, extract:
+
+- **Layer** — from `@layer: unit|integration|e2e|contract` annotation, or infer from file path/name conventions (`test_unit_*`, `*_integration_test.*`, `*_e2e_*`, etc.)
+- **Behavior** — from `@behavior:` annotation, or the test function docstring, or the test function name (converted from snake_case)
+- **Polarity** — from `@polarity: positive|negative` annotation, or infer from test name suffix (`_positive`, `_negative`, `_invalid`, `_missing`, `_error`, etc.)
+- **File** — the test file path (already known from the search)
+- **Test Name** — the test function name
+
+**Fallback:** If no `@spec`/`@regression` annotations are found in any test file, fall back to reading `context/spec/[target-spec]/tasks.md`. Find the "Feature Testing & Regression" slice and list each `**[Agent: testing-expert]**` sub-task as a single candidate entry, marking Layer/Behavior/Polarity as "pending discovery". Inform the user that annotations were not found.
+
+Build a candidate table:
+
+```
+| # | Layer       | Behavior                              | Polarity | File                           | Test Name               |
+|---|-------------|---------------------------------------|----------|--------------------------------|-------------------------|
+| 1 | unit        | token payload, expiry, signing        | positive | tests/test_auth.py             | test_token_payload      |
+| 2 | unit        | invalid secret, expired token         | negative | tests/test_auth.py             | test_invalid_token      |
+| 3 | integration | valid credentials against /auth       | positive | tests/test_auth_integration.py | test_auth_happy_path    |
+```
+
+## Step 3: Load existing regression suite and detect duplicates
+
+Read `context/qa/regression-suite.md`. If it does not exist, create it from `templates/regression-suite-template.md`.
+
+For each candidate from Step 2, compare against every existing entry in `regression-suite.md`:
+
+**Duplicate detection rules:**
+- **Exact duplicate** — same spec, same layer, same behavior description (case-insensitive) → mark `DUPLICATE — skip`
+- **Extendable** — same spec, same layer, similar behavior (≥70% word overlap) but different polarity OR slightly different scope → mark `EXTEND — merge into existing entry`
+- **New** — no match found → mark `NEW — add to suite`
+
+Build a resolution table to show the user:
+
+```
+| # | Candidate Behavior              | Layer | Resolution         | Existing Entry (if any)            |
+|---|----------------------------------|-------|--------------------|------------------------------------|
+| 1 | token payload, expiry, signing  | unit  | NEW                | —                                  |
+| 2 | invalid secret, expired token   | unit  | EXTEND             | "token validation" in 001-user-auth|
+| 3 | valid credentials against /auth | intg  | DUPLICATE — skip   | "auth endpoint happy path"         |
+```
+
+## Step 4: User confirmation
+
+Present the candidate table and resolution table to the user. Use `AskUserQuestion`:
+
+```
+Found N test candidates from spec [spec-name].
+- X are NEW → will be added to regression suite
+- Y are EXTEND → will be merged into existing entries
+- Z are DUPLICATE → will be skipped
+
+Do you want to proceed with this plan, or adjust it?
+```
+
+Options:
+- **Proceed as proposed** — apply all resolutions as shown
+- **Review manually** — list each NEW/EXTEND one by one and ask approve/skip/modify
+- **Cancel** — exit without changes
+
+Wait for user confirmation before modifying any files.
+
+## Step 5: Update `regression-suite.md`
+
+Apply confirmed resolutions:
+
+**For NEW entries** — add under the correct spec section and layer subsection:
+```markdown
+## [spec-directory-name] — [Feature Title from functional-spec.md]
+
+### Unit
+| File | Test Name | Behavior | Polarity | Status | Notes |
+|------|-----------|----------|----------|--------|-------|
+| tests/test_auth.py | test_token_payload | token payload, expiry, signing | positive | OK | — |
+
+### Integration
+...
+
+### E2E
+...
+```
+
+Create the spec section if it doesn't exist. Create layer subsection if it doesn't exist.
+
+**For EXTEND entries** — append the new polarity or scope detail to the Notes column of the existing entry. Do not create a new row.
+
+**For DUPLICATE entries** — skip. Do not modify anything.
+
+Update the header:
+```markdown
+**Last updated:** YYYY-MM-DD
+**Total:** N tests  ← recalculate: count all rows across all sections
+```
+
+## Step 6: Run regression suite (with user confirmation)
+
+1. Count all tests currently in `regression-suite.md` (all rows across all sections).
+2. Use `AskUserQuestion`:
+
+   ```
+   Regression suite updated: N total tests ([spec] added M new).
+
+   Run the regression suite now?
+   ```
+
+   Options:
+   - **Run full suite** — run all N tests
+   - **Run only new tests** — run only the M tests just added
+   - **Skip — I'll run manually** — exit after updating the suite file
+
+3. If user chooses to run:
+   - Detect test runner: check for `docker-compose.yml`, `Makefile` (with `test` target), `package.json` (`test` script), `pytest.ini` / `pyproject.toml`, `justfile`.
+   - If runner found: spin up infrastructure if needed, run the selected tests, capture output.
+   - If NO runner found: inform user — "No test runner detected. Tests are saved in regression-suite.md. Run them manually using your project's test command." Proceed to Step 7.
+
+4. Collect results per test: PASS / FAIL / ERROR / SKIPPED.
+
+## Step 7: Generate report
+
+Save to `context/qa/regression-reports/regression-YYYY-MM-DD-[spec-name].md`:
+
+```markdown
+# Regression Report — YYYY-MM-DD
+
+## Feature
+[spec-directory-name] — [Feature Title]
+
+## Suite Delta
+- Added: N new tests
+- Extended: M existing entries
+- Skipped (duplicates): K
+
+## Regression Suite Status
+**Total tests in suite:** N
+
+## Run Results
+[If tests were run:]
+- Suite: [Full / New tests only]
+- Passed: N | Failed: M | Errors: K | Skipped: J
+
+### Failed Tests
+| File | Test Name | Layer | Error |
+|------|-----------|-------|-------|
+| ...  | ...       | ...   | ...   |
+
+[If tests were NOT run:]
+- Tests were not executed this session. Run manually with [detected command or "your project's test command"].
+
+## Recommendations
+- [ ] [Any failing tests that need attention]
+- [ ] [Suggested follow-up if infrastructure was missing]
+```
+
+Announce summary to user in chat.
+
+---
+
+# CONSTRAINTS
+
+- Never write new tests — only promote existing ones from tasks.md.
+- Never auto-delete entries from regression-suite.md — only add or extend.
+- Always ask for user confirmation before modifying regression-suite.md (Step 4).
+- Always ask for user confirmation before running tests (Step 6).
+- If a test file path cannot be found in the codebase, mark it "pending discovery" in the suite — do not skip it.
+- Never delete existing entries from `regression-suite.md` under any circumstances — if a user requests deletion, flag it for human review instead.

--- a/commands/regression.md
+++ b/commands/regression.md
@@ -52,7 +52,7 @@ After a feature's "Feature Testing & Regression" slice is complete, run this com
 
 ## Step 2: Extract test candidates from test files
 
-Search the codebase for test files containing both `@spec: [target-spec]` and `@regression` annotations. These annotations are written by `testing-expert` during the Feature Testing & Regression slice.
+**Primary source (always try first):** Search the codebase for test files containing both `@spec: [target-spec]` and `@regression` annotations. These annotations are written by `testing-expert` during the Feature Testing & Regression slice.
 
 For each annotated test function found, extract:
 
@@ -62,11 +62,11 @@ For each annotated test function found, extract:
 - **File** — the test file path (already known from the search)
 - **Test Name** — the test function name
 
-**Fallback:** If no `@spec`/`@regression` annotations are found in any test file, fall back to reading `context/spec/[target-spec]/tasks.md`. Find the "Feature Testing & Regression" slice and list each `**[Agent: testing-expert]**` sub-task as a single candidate entry, marking Layer/Behavior/Polarity as "pending discovery". Inform the user that annotations were not found.
+**Fallback (only if primary source returns zero results):** Read `context/spec/[target-spec]/tasks.md`. Find the "Feature Testing & Regression" slice and list each `**[Agent: testing-expert]**` sub-task as a single candidate entry, marking Layer/Behavior/Polarity as "pending discovery". Inform the user that annotations were not found and entries are marked for future discovery.
 
 Build a candidate table:
 
-```
+```markdown
 | # | Layer       | Behavior                              | Polarity | File                           | Test Name               |
 |---|-------------|---------------------------------------|----------|--------------------------------|-------------------------|
 | 1 | unit        | token payload, expiry, signing        | positive | tests/test_auth.py             | test_token_payload      |
@@ -88,7 +88,7 @@ For each candidate from Step 2, compare against every existing entry in `regress
 
 Build a resolution table to show the user:
 
-```
+```markdown
 | # | Candidate Behavior              | Layer | Resolution         | Existing Entry (if any)            |
 |---|----------------------------------|-------|--------------------|------------------------------------|
 | 1 | token payload, expiry, signing  | unit  | NEW                | —                                  |
@@ -100,7 +100,7 @@ Build a resolution table to show the user:
 
 Present the candidate table and resolution table to the user. Use `AskUserQuestion`:
 
-```
+```text
 Found N test candidates from spec [spec-name].
 - X are NEW → will be added to regression suite
 - Y are EXTEND → will be merged into existing entries
@@ -159,7 +159,7 @@ Update the header:
 1. Count all tests currently in `regression-suite.md` (all rows across all sections).
 2. Use `AskUserQuestion`:
 
-   ```
+   ```text
    Regression suite updated: N total tests ([spec] added M new).
 
    Run the regression suite now?

--- a/commands/regression.md
+++ b/commands/regression.md
@@ -67,11 +67,11 @@ For each annotated test function found, extract:
 Build a candidate table:
 
 ```markdown
-| # | Layer       | Behavior                              | Polarity | File                           | Test Name               |
-|---|-------------|---------------------------------------|----------|--------------------------------|-------------------------|
-| 1 | unit        | token payload, expiry, signing        | positive | tests/test_auth.py             | test_token_payload      |
-| 2 | unit        | invalid secret, expired token         | negative | tests/test_auth.py             | test_invalid_token      |
-| 3 | integration | valid credentials against /auth       | positive | tests/test_auth_integration.py | test_auth_happy_path    |
+| #   | Layer       | Behavior                        | Polarity | File                           | Test Name            |
+| --- | ----------- | ------------------------------- | -------- | ------------------------------ | -------------------- |
+| 1   | unit        | token payload, expiry, signing  | positive | tests/test_auth.py             | test_token_payload   |
+| 2   | unit        | invalid secret, expired token   | negative | tests/test_auth.py             | test_invalid_token   |
+| 3   | integration | valid credentials against /auth | positive | tests/test_auth_integration.py | test_auth_happy_path |
 ```
 
 ## Step 3: Load existing regression suite and detect duplicates
@@ -89,11 +89,11 @@ For each candidate from Step 2, compare against every existing entry in `regress
 Build a resolution table to show the user:
 
 ```markdown
-| # | Candidate Behavior              | Layer | Resolution         | Existing Entry (if any)            |
-|---|----------------------------------|-------|--------------------|------------------------------------|
-| 1 | token payload, expiry, signing  | unit  | NEW                | —                                  |
-| 2 | invalid secret, expired token   | unit  | EXTEND             | "token validation" in 001-user-auth|
-| 3 | valid credentials against /auth | intg  | DUPLICATE — skip   | "auth endpoint happy path"         |
+| #   | Candidate Behavior              | Layer | Resolution       | Existing Entry (if any)             |
+| --- | ------------------------------- | ----- | ---------------- | ----------------------------------- |
+| 1   | token payload, expiry, signing  | unit  | NEW              | —                                   |
+| 2   | invalid secret, expired token   | unit  | EXTEND           | "token validation" in 001-user-auth |
+| 3   | valid credentials against /auth | intg  | DUPLICATE — skip | "auth endpoint happy path"          |
 ```
 
 ## Step 4: User confirmation

--- a/commands/regression.md
+++ b/commands/regression.md
@@ -11,6 +11,7 @@ You are a Regression Suite Manager. Your job is to review tests generated during
 # TASK
 
 After a feature's "Feature Testing & Regression" slice is complete, run this command to:
+
 1. Extract test candidates from the current feature's `tasks.md`
 2. Check them against the existing `regression-suite.md` for duplicates or extendable entries
 3. Ask the user to confirm the final selection
@@ -80,6 +81,7 @@ Read `context/qa/regression-suite.md`. If it does not exist, create it from `tem
 For each candidate from Step 2, compare against every existing entry in `regression-suite.md`:
 
 **Duplicate detection rules:**
+
 - **Exact duplicate** — same spec, same layer, same behavior description (case-insensitive) → mark `DUPLICATE — skip`
 - **Extendable** — same spec, same layer, similar behavior (≥70% word overlap) but different polarity OR slightly different scope → mark `EXTEND — merge into existing entry`
 - **New** — no match found → mark `NEW — add to suite`
@@ -108,6 +110,7 @@ Do you want to proceed with this plan, or adjust it?
 ```
 
 Options:
+
 - **Proceed as proposed** — apply all resolutions as shown
 - **Review manually** — list each NEW/EXTEND one by one and ask approve/skip/modify
 - **Cancel** — exit without changes
@@ -119,18 +122,22 @@ Wait for user confirmation before modifying any files.
 Apply confirmed resolutions:
 
 **For NEW entries** — add under the correct spec section and layer subsection:
+
 ```markdown
 ## [spec-directory-name] — [Feature Title from functional-spec.md]
 
 ### Unit
-| File | Test Name | Behavior | Polarity | Status | Notes |
-|------|-----------|----------|----------|--------|-------|
-| tests/test_auth.py | test_token_payload | token payload, expiry, signing | positive | OK | — |
+
+| File               | Test Name          | Behavior                       | Polarity | Status | Notes |
+| ------------------ | ------------------ | ------------------------------ | -------- | ------ | ----- |
+| tests/test_auth.py | test_token_payload | token payload, expiry, signing | positive | OK     | —     |
 
 ### Integration
+
 ...
 
 ### E2E
+
 ...
 ```
 
@@ -141,9 +148,10 @@ Create the spec section if it doesn't exist. Create layer subsection if it doesn
 **For DUPLICATE entries** — skip. Do not modify anything.
 
 Update the header:
+
 ```markdown
 **Last updated:** YYYY-MM-DD
-**Total:** N tests  ← recalculate: count all rows across all sections
+**Total:** N tests ← recalculate: count all rows across all sections
 ```
 
 ## Step 6: Run regression suite (with user confirmation)
@@ -177,30 +185,38 @@ Save to `context/qa/regression-reports/regression-YYYY-MM-DD-[spec-name].md`:
 # Regression Report — YYYY-MM-DD
 
 ## Feature
+
 [spec-directory-name] — [Feature Title]
 
 ## Suite Delta
+
 - Added: N new tests
 - Extended: M existing entries
 - Skipped (duplicates): K
 
 ## Regression Suite Status
+
 **Total tests in suite:** N
 
 ## Run Results
+
 [If tests were run:]
+
 - Suite: [Full / New tests only]
 - Passed: N | Failed: M | Errors: K | Skipped: J
 
 ### Failed Tests
+
 | File | Test Name | Layer | Error |
-|------|-----------|-------|-------|
+| ---- | --------- | ----- | ----- |
 | ...  | ...       | ...   | ...   |
 
 [If tests were NOT run:]
+
 - Tests were not executed this session. Run manually with [detected command or "your project's test command"].
 
 ## Recommendations
+
 - [ ] [Any failing tests that need attention]
 - [ ] [Suggested follow-up if infrastructure was missing]
 ```

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -69,7 +69,7 @@ Follow this process precisely.
       - Append the subagent assignment using format: `**[Agent: agent-name]**` at the end of the sub-task description
       - Use `general-purpose` agent when no specialist clearly matches the task — but **track these assignments** for the Recommendations table
   5.  After the verification sub-task, add a cleanup sub-task as the last item of the slice:
-      ```
+      ```md
       - [ ] Cleanup: Delete any screenshots, videos, or e2e scripts generated during this slice's verification. **[Agent: general-purpose]**
       ```
       Skip this sub-task for the **Feature Testing & Regression** slice — its artifacts are kept intentionally.
@@ -80,7 +80,7 @@ Follow this process precisely.
 
       After all implementation slices are defined, append one final slice. This slice is generated automatically — do not ask the user about it.
 
-      ```
+      ```md
       - [ ] **Slice N: Feature Testing & Regression**
         > Verifies the complete feature works end-to-end as described in functional-spec.md.
         > Run AFTER all implementation slices are complete.
@@ -127,7 +127,7 @@ Follow this process precisely.
     - `[ ] **Slice 3: Feature Testing & Regression**`
       - `> Verifies the complete feature works end-to-end as described in functional-spec.md.`
       - `> Run AFTER all implementation slices are complete.`
-      - `> **Requires \`testing-expert\` agent.\*\* If it is not present in \`.claude/agents/\`, stop and run \`/awos:hire\` before executing this slice.`
+      - `> **Requires \`testing-expert\` agent.** If it is not present in \`.claude/agents/\`, stop and run \`/awos:hire\` before executing this slice.`
       - `[ ] Read functional-spec.md acceptance criteria in full. Generate acceptance-level tests that verify the entire feature as a whole — not individual slices. Cover applicable layers (unit for pure logic, integration for service interactions, e2e for user flows). Write tests with RED validation (must fail before implementation is confirmed done). Annotate each test with \`@spec: [spec-directory]\` and \`@regression\` if suitable for long-term regression. **[Agent: testing-expert]**`
       - `[ ] Run all generated tests. All must pass. Fix any failures before proceeding. **[Agent: testing-expert]**`
       - `[ ] Run \`/awos:regression [spec-directory-name]\` to review candidates for the regression suite, resolve duplicates, and optionally execute the full regression suite. Pass the current spec directory name as the argument (e.g., \`/awos:regression 003-user-avatar\`). Do not run without an argument — auto-detection requires all tasks to be complete, which is not yet the case.`

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -82,11 +82,11 @@ Follow this process precisely.
 
       ```md
       - [ ] **Slice N: Feature Testing & Regression**
+
         > Verifies the complete feature works end-to-end as described in functional-spec.md.
         > Run AFTER all implementation slices are complete.
         > **Requires `testing-expert` agent.** If it is not present in `.claude/agents/`,
         > stop and run `/awos:hire` before executing this slice.
-
         - [ ] Read functional-spec.md acceptance criteria in full. Generate acceptance-level tests
               that verify the entire feature as a whole — not individual slices. Cover applicable
               layers (unit for pure logic, integration for service interactions, e2e for user flows).
@@ -127,7 +127,7 @@ Follow this process precisely.
     - `[ ] **Slice 3: Feature Testing & Regression**`
       - `> Verifies the complete feature works end-to-end as described in functional-spec.md.`
       - `> Run AFTER all implementation slices are complete.`
-      - `> **Requires \`testing-expert\` agent.** If it is not present in \`.claude/agents/\`, stop and run \`/awos:hire\` before executing this slice.`
+      - `> **Requires \`testing-expert\` agent.\*\* If it is not present in \`.claude/agents/\`, stop and run \`/awos:hire\` before executing this slice.`
       - `[ ] Read functional-spec.md acceptance criteria in full. Generate acceptance-level tests that verify the entire feature as a whole — not individual slices. Cover applicable layers (unit for pure logic, integration for service interactions, e2e for user flows). Write tests with RED validation (must fail before implementation is confirmed done). Annotate each test with \`@spec: [spec-directory]\` and \`@regression\` if suitable for long-term regression. **[Agent: testing-expert]**`
       - `[ ] Run all generated tests. All must pass. Fix any failures before proceeding. **[Agent: testing-expert]**`
       - `[ ] Run \`/awos:regression [spec-directory-name]\` to review candidates for the regression suite, resolve duplicates, and optionally execute the full regression suite. Pass the current spec directory name as the argument (e.g., \`/awos:regression 003-user-avatar\`). Do not run without an argument — auto-detection requires all tasks to be complete, which is not yet the case.`

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -53,6 +53,7 @@ Follow this process precisely.
   - You must **check and require all needed MCPs, services, and dependencies** for testing. If something is missing, instruct the user to install it.
   - If a slice **cannot be tested**, explain why and **get user approval** before proceeding.
   - A slice **is not complete** unless it is tested or explicitly approved to skip testing.
+  - After a slice is verified and marked complete, **delete all temporary artifacts** generated during that slice's verification — screenshots, recorded videos, generated e2e test scripts, and any other ephemeral files produced by the e2e-tester or browser MCP. Exception: do **not** delete artifacts from the **Feature Testing & Regression** slice — those are intentionally kept for the regression suite.
 
 - **Your Thought Process for Generating Tasks:**
   1.  First, identify the absolute smallest piece of user-visible value from the spec. This is your **Slice 1**.
@@ -60,17 +61,50 @@ Follow this process precisely.
   3.  Under that slice, create the nested sub-tasks (database, backend, frontend) needed to implement and verify **only that slice**.
   4.  **For each sub-task, assign the appropriate subagent:**
       - Analyze the sub-task description to understand what technology/domain it involves
-      - Analyze the Task tool definition to extract all available subagent_type values with their descriptions to understand what subagents are available for assignment.
+      - Analyze the Task tool definition to extract all available `subagent_type` values with their descriptions to understand what subagents are available for assignment
       - Match the sub-task to a subagent based on:
         - Technology keywords
         - Task intent
-        - Tech stack identified in technical-considerations.md
+        - Tech stack identified in `technical-considerations.md`
       - Append the subagent assignment using format: `**[Agent: agent-name]**` at the end of the sub-task description
       - Use `general-purpose` agent when no specialist clearly matches the task — but **track these assignments** for the Recommendations table
-  5.  Next, identify the second-smallest piece of value that builds on the first. This is **Slice 2**.
-  6.  Create a high-level checklist item and its sub-tasks with subagent assignments.
-  7.  Repeat this process until all requirements from the specification are covered.
-  8.  For each slice's verification sub-task, identify required MCPs/services (browser MCP, curl, database access, etc.) and note any that may be missing.
+  5.  After the verification sub-task, add a cleanup sub-task as the last item of the slice:
+      ```
+      - [ ] Cleanup: Delete any screenshots, videos, or e2e scripts generated during this slice's verification. **[Agent: general-purpose]**
+      ```
+      Skip this sub-task for the **Feature Testing & Regression** slice — its artifacts are kept intentionally.
+  6.  Next, identify the second-smallest piece of value that builds on the first. This is **Slice 2**.
+  7.  Create a high-level checklist item and its sub-tasks with subagent assignments.
+  8.  Repeat this process until all requirements from the specification are covered.
+  9.  **Add the Feature Testing & Regression slice (always last):**
+
+      After all implementation slices are defined, append one final slice. This slice is generated automatically — do not ask the user about it.
+
+      ```
+      - [ ] **Slice N: Feature Testing & Regression**
+        > Verifies the complete feature works end-to-end as described in functional-spec.md.
+        > Run AFTER all implementation slices are complete.
+        > **Requires `testing-expert` agent.** If it is not present in `.claude/agents/`,
+        > stop and run `/awos:hire` before executing this slice.
+
+        - [ ] Read functional-spec.md acceptance criteria in full. Generate acceptance-level tests
+              that verify the entire feature as a whole — not individual slices. Cover applicable
+              layers (unit for pure logic, integration for service interactions, e2e for user flows).
+              Write tests with RED validation (must fail before implementation is confirmed done).
+              Annotate each test with `@spec: [spec-directory]` and `@regression` if suitable
+              for long-term regression. **[Agent: testing-expert]**
+        - [ ] Run all generated tests. All must pass. Fix any failures before proceeding.
+              **[Agent: testing-expert]**
+        - [ ] Run `/awos:regression [spec-directory-name]` to review candidates for the
+              regression suite, resolve duplicates, and optionally execute the full
+              regression suite. Pass the current spec directory name as the argument
+              (e.g., `/awos:regression 003-user-avatar`). Do not run without an argument —
+              auto-detection requires all tasks to be complete, which is not yet the case.
+      ```
+
+      Replace `N` with the actual next slice number. Do not change the wording — agents
+      downstream depend on this exact structure.
+  10. For each slice's verification sub-task, identify required MCPs/services (browser MCP, curl, database access, etc.) and note any that may be missing.
 
 - **Example of applying the rule for "User Profile Picture Upload":**
   - **Bad, Horizontal Tasks (DO NOT DO THIS):**
@@ -81,11 +115,21 @@ Follow this process precisely.
     - `[ ] **Slice 1: Display a placeholder avatar on the profile page**`
       - `[ ] Sub-task: Add a non-functional 'ProfileAvatar' UI component that shows a static placeholder image. **[Agent: react-expert]**`
       - `[ ] Sub-task: Place the component on the profile page. **[Agent: react-expert]**`
+      - `[ ] Verify: Start the app, open the profile page, confirm placeholder avatar is shown **[Agent: manual-qa-expert]**`
+      - `[ ] Cleanup: Delete any screenshots, videos, or e2e scripts generated during this slice's verification. **[Agent: general-purpose]**`
     - `[ ] **Slice 2: Display the user's actual avatar if it exists**`
       - `[ ] Sub-task: Add avatar_url column to the users table via a migration. **[Agent: python-expert]**`
       - `[ ] Sub-task: Update the user API endpoint to return the avatar_url. **[Agent: python-expert]**`
       - `[ ] Sub-task: Update the 'ProfileAvatar' component to fetch and display the user's avatar_url, falling back to the placeholder if null. **[Agent: react-expert]**`
       - `[ ] Sub-task: Run the application. Use chrome MCP to connect the page in Browser. Verify that the profile page shows the correct avatar or placeholder. **[Agent: manual-qa-expert]**`
+      - `[ ] Cleanup: Delete any screenshots, videos, or e2e scripts generated during this slice's verification. **[Agent: general-purpose]**`
+    - `[ ] **Slice 3: Feature Testing & Regression**`
+      - `> Verifies the complete feature works end-to-end as described in functional-spec.md.`
+      - `> Run AFTER all implementation slices are complete.`
+      - `> **Requires \`testing-expert\` agent.** If it is not present in \`.claude/agents/\`, stop and run \`/awos:hire\` before executing this slice.`
+      - `[ ] Read functional-spec.md acceptance criteria in full. Generate acceptance-level tests that verify the entire feature as a whole — not individual slices. Cover applicable layers (unit for pure logic, integration for service interactions, e2e for user flows). Write tests with RED validation (must fail before implementation is confirmed done). Annotate each test with \`@spec: [spec-directory]\` and \`@regression\` if suitable for long-term regression. **[Agent: testing-expert]**`
+      - `[ ] Run all generated tests. All must pass. Fix any failures before proceeding. **[Agent: testing-expert]**`
+      - `[ ] Run \`/awos:regression [spec-directory-name]\` to review candidates for the regression suite, resolve duplicates, and optionally execute the full regression suite. Pass the current spec directory name as the argument (e.g., \`/awos:regression 003-user-avatar\`). Do not run without an argument — auto-detection requires all tasks to be complete, which is not yet the case.`
 
 ## Step 4: Present Draft and Refine
 

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -104,6 +104,7 @@ Follow this process precisely.
 
       Replace `N` with the actual next slice number. Do not change the wording — agents
       downstream depend on this exact structure.
+
   10. For each slice's verification sub-task, identify required MCPs/services (browser MCP, curl, database access, etc.) and note any that may be missing.
 
 - **Example of applying the rule for "User Profile Picture Upload":**
@@ -126,7 +127,7 @@ Follow this process precisely.
     - `[ ] **Slice 3: Feature Testing & Regression**`
       - `> Verifies the complete feature works end-to-end as described in functional-spec.md.`
       - `> Run AFTER all implementation slices are complete.`
-      - `> **Requires \`testing-expert\` agent.** If it is not present in \`.claude/agents/\`, stop and run \`/awos:hire\` before executing this slice.`
+      - `> **Requires \`testing-expert\` agent.\*\* If it is not present in \`.claude/agents/\`, stop and run \`/awos:hire\` before executing this slice.`
       - `[ ] Read functional-spec.md acceptance criteria in full. Generate acceptance-level tests that verify the entire feature as a whole — not individual slices. Cover applicable layers (unit for pure logic, integration for service interactions, e2e for user flows). Write tests with RED validation (must fail before implementation is confirmed done). Annotate each test with \`@spec: [spec-directory]\` and \`@regression\` if suitable for long-term regression. **[Agent: testing-expert]**`
       - `[ ] Run all generated tests. All must pass. Fix any failures before proceeding. **[Agent: testing-expert]**`
       - `[ ] Run \`/awos:regression [spec-directory-name]\` to review candidates for the regression suite, resolve duplicates, and optionally execute the full regression suite. Pass the current spec directory name as the argument (e.g., \`/awos:regression 003-user-avatar\`). Do not run without an argument — auto-detection requires all tasks to be complete, which is not yet the case.`

--- a/templates/regression-suite-template.md
+++ b/templates/regression-suite-template.md
@@ -1,0 +1,37 @@
+# Regression Suite
+
+> Auto-maintained by `/awos:regression`.
+> Run with: `/awos:regression` → choose "Run full suite" or "Run only new tests".
+> Each spec section is added when that feature's regression slice is processed.
+> Do NOT manually add entries — use `/awos:regression` to ensure deduplication.
+
+**Last updated:** YYYY-MM-DD
+**Total:** 0 tests
+
+---
+
+<!-- Spec sections are added here by /awos:regression. Format:
+
+## [spec-directory-name] — [Feature Title]
+
+### Unit
+| File | Test Name | Behavior | Polarity | Status | Notes |
+|------|-----------|----------|----------|--------|-------|
+| path/to/test.py | test_function_name | brief behavior description | positive | OK | — |
+
+### Integration
+| File | Test Name | Behavior | Polarity | Status | Notes |
+|------|-----------|----------|----------|--------|-------|
+
+### E2E
+| File | Test Name | Behavior | Polarity | Status | Notes |
+|------|-----------|----------|----------|--------|-------|
+
+### Contract
+| File | Test Name | Behavior | Polarity | Status | Notes |
+|------|-----------|----------|----------|--------|-------|
+
+Status values: OK | FAILING | NEEDS UPDATE | PENDING DISCOVERY
+Polarity values: positive | negative
+
+-->


### PR DESCRIPTION
## Summary

- **`/awos:regression`** — new command for managing the long-term regression suite. After a feature's Testing & Regression slice is complete, it: extracts test candidates from annotated test files (`@spec`, `@regression`), deduplicates against the existing suite, asks the user to confirm the selection, updates `context/qa/regression-suite.md`, optionally runs the suite, and generates a dated report at `context/qa/regression-reports/regression-YYYY-MM-DD-[spec].md`.
- **`templates/regression-suite-template.md`** — starter template for `context/qa/regression-suite.md`, used on first run if the file doesn't exist.
- **`commands/tasks.md`** — uncomments the `/awos:regression` sub-task inside the Feature Testing & Regression slice (was commented out in PR #109 pending this merge).

## Merge order

**Merge after PR #109.** This PR's `commands/tasks.md` includes all changes from #109 plus the enabled regression sub-task.

## File map

```
commands/regression.md          ← /awos:regression command
claude/commands/regression.md   ← thin Claude Code wrapper
templates/
  regression-suite-template.md  ← regression suite scaffold
commands/tasks.md               ← /awos:regression sub-task enabled
```

## Test plan

- [ ] Complete all implementation slices + Feature Testing & Regression slice on a spec
- [ ] Run `/awos:regression [spec-name]` — confirm candidates are extracted from annotated test files
- [ ] Confirm deduplication works against an existing `regression-suite.md`
- [ ] Confirm `regression-suite.md` is updated after user approval
- [ ] Confirm dated report is generated in `context/qa/regression-reports/`
- [ ] Run without argument — confirm auto-detection finds the completed spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)