### PR TITLE
fix(installer): use path.relative for copy-log paths on Windows

### DIFF
--- a/src/services/file-copier.js
+++ b/src/services/file-copier.js
@@ -60,7 +60,7 @@ async function copyFile({
     await fsPromises.copyFile(sourcePath, destinationPath);
 
     // Log the result
-    const relativePath = destinationPath.replace(targetDir + '/', '');
+    const relativePath = path.relative(targetDir, destinationPath);
 
     if (destinationExists) {
       log(`Updated ${relativePath}`, 'success');
@@ -103,7 +103,7 @@ async function copyDirectory({
 
   // Check if destination directory already exists
   const destinationExists = await pathExists(destinationDir);
-  const relativePath = destinationDir.replace(targetDir + '/', '');
+  const relativePath = path.relative(targetDir, destinationDir);
 
   if (!destinationExists) {
     await fsPromises.mkdir(destinationDir, { recursive: true });


### PR DESCRIPTION
## Summary

- `relativePath` in `src/services/file-copier.js` was computed via `destinationPath.replace(targetDir + '/', '')` to strip the target dir prefix
- The hardcoded `/` never matches on Windows (where `path.join` produces `\`), so the replace silently returns the original string and every `Copied` / `Updated` / `Created` log line shows the full absolute path
- Switch both call sites (lines 63 and 106) to `path.relative(targetDir, …)` — Node's stdlib function for exactly this case
- POSIX output unchanged; on Windows logs now show `.awos\commands\architecture.md` instead of `C:\Users\...\.awos\commands\architecture.md`
- No on-disk behavior change: `diff -rq` between two clean installs (one with bug, one with fix) returns empty

## Test plan

- [x] Fresh install into empty dir on Windows — `Copied` / `Created` lines render clean relative paths
- [x] Re-run installer in populated dir — `Updated` and `already exists` lines also clean
- [x] `--dry-run` summary unchanged (5 dirs, 25 files, MCP + marketplace configured)
- [x] `diff -rq before-fix/ after-fix/` returns empty — filesystem behavior identical
- [x] `npx prettier --write src/services/file-copier.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative path computation in file and directory copy operations for more accurate logging and display of destination paths, including better handling of edge cases with path separators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/provectus/awos/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->