### PR TITLE
fix(installer): identify the malformed file when JSON.parse fails in configurators

### DIFF
--- a/src/services/marketplace-configurator.js
+++ b/src/services/marketplace-configurator.js
@@ -39,7 +39,11 @@ async function configureMarketplace({ workingDir, dryRun = false }) {
 
   if (fileExists) {
     const content = await fsPromises.readFile(settingsPath, 'utf-8');
-    settings = JSON.parse(content);
+    try {
+      settings = JSON.parse(content);
+    } catch (error) {
+      throw new Error(`Invalid JSON in ${SETTINGS_FILE}: ${error.message}`);
+    }
   }
 
   if (!settings.extraKnownMarketplaces) {

--- a/src/services/mcp-configurator.js
+++ b/src/services/mcp-configurator.js
@@ -37,7 +37,11 @@ async function configureMcp({ workingDir, dryRun = false }) {
 
   if (fileExists) {
     const content = await fsPromises.readFile(mcpPath, 'utf-8');
-    config = JSON.parse(content);
+    try {
+      config = JSON.parse(content);
+    } catch (error) {
+      throw new Error(`Invalid JSON in ${MCP_FILE}: ${error.message}`);
+    }
   }
 
   if (!config.mcpServers) {


### PR DESCRIPTION
## Summary

The MCP and marketplace configurators call `JSON.parse` on existing user JSON files without a try/catch. If `.mcp.json` or `.claude/settings.json` is malformed (mid-edit, copy-paste, manual tweak), the installer crashes with a cryptic `SyntaxError` pointing at internal source lines — the user has no idea which of *their* files is broken.

Worse: the crash happens at step 5/6 (after steps 1-4 already ran), leaving the user with a half-installed project plus an unclear error.

This wraps both `JSON.parse` calls in try/catch and re-throws with a clear `Invalid JSON in <file>: <reason>` message. The pattern mirrors `src/migrations/runner.js:58-63`, which already does exactly this for migration JSON files — applying it consistently to the two configurators.

## Before

User has a half-edited `.mcp.json`:

```
{
  "mcpServers": {
    "my-server": {
      "command": "node"
```

Installer output (last lines):

```
[5/6] Configuring MCP - Setting up MCP server configuration

  ✗ Error during setup: Expected ',' or '}' after property value in JSON at position 63 (line 5 column 1)
SyntaxError: Expected ',' or '}' after property value in JSON at position 63 (line 5 column 1)
    at JSON.parse (<anonymous>)
    at configureMcp (.../src/services/mcp-configurator.js:40:19)
    at async runSetup (.../src/core/setup-orchestrator.js:98:25)
    at async main (.../src/index.js:22:5)
```

The user has to read the stack trace and guess from the function name `configureMcp` that `.mcp.json` is the file to fix. Steps 1-4 already ran — `.awos/`, `.claude/commands/`, `context/` are now on disk.

## After

Same starting state, same installer run:

```
[5/6] Configuring MCP - Setting up MCP server configuration

  ✗ Error during setup: Invalid JSON in .mcp.json: Expected ',' or '}' after property value in JSON at position 63 (line 5 column 1)
Error: Invalid JSON in .mcp.json: Expected ',' or '}' after property value in JSON at position 63 (line 5 column 1)
    at configureMcp (.../src/services/mcp-configurator.js:43:13)
    at async runSetup (.../src/core/setup-orchestrator.js:98:25)
    at async main (.../src/index.js:22:5)
```

File name is named in the first line of the error; underlying parser detail (line 5, column 1, expected `,` or `}`) preserved so the user can locate and fix it.

## Why this fix is safe

- **Established pattern in same repo:** `src/migrations/runner.js:58-63` already does:
  ```js
  try {
    const migration = JSON.parse(content);
    migrations.push(migration);
  } catch (error) {
    throw new Error(`Invalid migration JSON in ${file}: ${error.message}`);
  }
  ```
  This PR applies the same shape to the two configurators that were missed.
- **No prior fix attempts** on any of the 25 active branches (verified by pickaxe across the file).
- **No downstream consumers** depend on the crash format. Only callers are two `await` lines in `src/core/setup-orchestrator.js`; both use only the return value, not the exception shape.
- **No tests break.** The unmerged test suite in `tests/installer/setup-orchestrator.test.js` (PR #117) asserts only happy-path file creation; doesn't exercise malformed input. Safe to coexist.
- **Readfile errors still propagate raw.** The `try` only wraps `JSON.parse`, not the `readFile`. EISDIR / ENOENT race / permission denied all surface unchanged.

## Test plan

Verified across four scenarios in a Windows pet project:

- [x] **Malformed `.mcp.json`** → `Error during setup: Invalid JSON in .mcp.json: ...`, exit 1
- [x] **Malformed `.claude/settings.json`** → `Error during setup: Invalid JSON in .claude/settings.json: ...`, exit 1
- [x] **Happy path (fresh install, no existing files)** → 5 dirs / 25 files / MCP + marketplace configured, exit 0
- [x] **`--dry-run` on empty dir** → preview only, no on-disk changes, exit 0
- [x] **Idempotency** — re-running after a successful install produces no errors (`.mcp.json` and `.claude/settings.json` now exist as well-formed files, parse succeeds, configurators skip re-config)
- [x] `npx prettier --write` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when configuration files contain invalid JSON, providing clearer feedback instead of raw parsing errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/provectus/awos/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->