### PR TITLE
refactor(installer): drop unused dryRun arg passed to copyDirectory

### DIFF
--- a/src/services/file-copier.js
+++ b/src/services/file-copier.js
@@ -229,7 +229,6 @@ async function executeCopyOperations({
         patterns: operation.patterns,
         description: operation.description,
         stats,
-        dryRun,
       });
     }
   }


### PR DESCRIPTION
## Summary

- `executeCopyOperations` passes `dryRun` to `copyDirectory` at `src/services/file-copier.js:225-233`, but `copyDirectory`'s destructured signature (line 87-94) doesn't accept it — the value is discarded.
- `executeCopyOperations` already short-circuits the dry-run case at line 206 (routes to `countFiles`), so `copyDirectory` is never reached when `dryRun=true`. The arg passed at line 232 is always `false` AND always unread.
- The arg has been dead since commit [`9517694`](https://github.com/provectus/awos/commit/9517694) (Oct 22, 2025) — ~7 months, present on all 19 branches that have this file.
- This PR removes the one-line dead key from the object literal. Pure cleanup; no runtime change.

## Categorization note

This is dead-code removal, not a bug fix in the user-visible sense. Maintainers may want to relabel from `bug` (cross-fork apply will silently fail anyway) to a maintenance/chore category — the release-drafter config maps `chore`→🧰 Maintenance but no such label exists upstream today. Whatever maintainers prefer.

## Why this is safe

- **Provably no runtime change.** `diff -rq` between two clean installer runs (one from main, one from this branch) returns empty — filesystem byte-identical. Same on `--dry-run`.
- **No prior fix attempts** on any of the 19 branches with this file (verified by pickaxe across all remote refs).
- **No external consumers** of `copyDirectory` — only called from inside `file-copier.js` itself (recursive + the main call at line 225). Not exported from the module (see `module.exports = { executeCopyOperations };` at line 240).
- **No tests depend on the dead arg.** The unmerged installer test suite (`tests/installer/file-copier.test.js` in PR #117) exercises `executeCopyOperations({ dryRun: true })`, which takes the `if` branch and never reaches `copyDirectory`. The dead arg lives in the unreachable-for-this-test `else` branch.

## Test plan

Verified on Windows:

- [x] **Fresh install (main)** → 5 dirs / 25 files / MCP + marketplace configured, exit 0
- [x] **Fresh install (fix branch)** → 5 dirs / 25 files / MCP + marketplace configured, exit 0
- [x] **`diff -rq` between the two install trees** → empty (byte-identical)
- [x] **`--dry-run` from main** → preview summary `5 / 25 / 0 / 1 / 1`
- [x] **`--dry-run` from fix branch** → identical preview summary
- [x] **`diff -rq` between the two dry-run dirs** → empty
- [x] `npx prettier --write src/services/file-copier.js` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
