### PR TITLE
fix(tasks): split agent-discovery bullet so plugin-provided agents aren't skipped

### DIFF
--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -62,7 +62,10 @@ Follow this process precisely.
   3.  Under that slice, create the nested sub-tasks (database, backend, frontend) needed to implement and verify **only that slice**.
   4.  **For each sub-task, assign the appropriate subagent:**
       - Identify the technology or domain the sub-task involves
-      - Discover registered specialists from two sources, both routed through the built-in `Explore` agent: (a) scan `.claude/agents/*.md` and parse each agent's YAML frontmatter (`name`, `description`, `skills`) for project-local agents; (b) read the `Agent` tool's description block for plugin-provided agents (those whose `subagent_type` carries a `plugin-name:` prefix, e.g. `python-development:python-pro`). The combined list, plus the always-available built-in `general-purpose`, is the universe to match against — auto-dispatch metadata alone is not a substitute when the assignment must be definitive.
+      - Discover specialists from **both** sources below — finding agents in one does not satisfy the other. Delegate both reads to the built-in `Explore` agent to keep your context lean:
+        - **(a) Project-local agents:** scan `.claude/agents/*.md` and parse each agent's YAML frontmatter (`name`, `description`, `skills`).
+        - **(b) Plugin-provided agents:** read the `Agent` tool's description block and collect every agent whose `subagent_type` carries a `plugin-name:` prefix (e.g. `python-development:python-pro`).
+      - The combined list — agents from (a), from (b), and the always-available built-in `general-purpose` — is the universe to match against. Auto-dispatch metadata alone is not a substitute when the assignment must be definitive.
       - Match the sub-task to a subagent based on:
         - Technology keywords
         - Task intent


### PR DESCRIPTION
## Summary

`commands/tasks.md:65` packs two agent-discovery sources into a single dense bullet. Claude consistently satisfies the leading "Discover specialists" verb after the first source and never executes the second one — so `tasks.md` silently omits plugin-provided `**[Agent: <plugin>:<name>]**` markers even when the project has plugins enabled and the spec calls for those stacks.

This was caught by the `tasks-discovers-plugin-agents` scenario in [awos-qa](https://github.com/provectus/awos-qa). Session-log evidence (7 tool calls): `ls context/spec/` → `ls feature-dir` → `Read functional-spec.md` → `Read technical-considerations.md` → `ls .claude/agents/` → `Read local-misc-helper.md` → `Write tasks.md`. No `Agent` tool inspection, no `Explore` delegation, no plugin discovery. (a) ran; (b) was completely skipped.

## What changes

`commands/tasks.md` §"Your Thought Process for Generating Tasks" → Step 4, the "Discover specialists" bullet:

**Before** — one bullet, both sources comma/semicolon-separated:

> Discover registered specialists from two sources, both routed through the built-in `Explore` agent: (a) scan `.claude/agents/*.md` and parse each agent's YAML frontmatter (`name`, `description`, `skills`) for project-local agents; (b) read the `Agent` tool's description block for plugin-provided agents (those whose `subagent_type` carries a `plugin-name:` prefix, e.g. `python-development:python-pro`). The combined list, plus the always-available built-in `general-purpose`, is the universe to match against — auto-dispatch metadata alone is not a substitute when the assignment must be definitive.

**After** — parent bullet with explicit "both" rule, (a) and (b) as independent sub-bullets each with its own verb, combined-universe rule promoted to a sibling bullet:

> - Discover specialists from **both** sources below — finding agents in one does not satisfy the other. Delegate both reads to the built-in `Explore` agent to keep your context lean:
>   - **(a) Project-local agents:** scan `.claude/agents/*.md` and parse each agent's YAML frontmatter (`name`, `description`, `skills`).
>   - **(b) Plugin-provided agents:** read the `Agent` tool's description block and collect every agent whose `subagent_type` carries a `plugin-name:` prefix (e.g. `python-development:python-pro`).
> - The combined list — agents from (a), from (b), and the always-available built-in `general-purpose` — is the universe to match against. Auto-dispatch metadata alone is not a substitute when the assignment must be definitive.

## Why

Prompting principles at work:

- **Independent verbs.** (a) "scan" and (b) "read" each own a bullet, so satisfying one doesn't extinguish the verb that controls the other.
- **One bolded discipline rule per bullet.** `**both**` carries the load — "finding agents in one does not satisfy the other" is the line that protects against the previous failure mode without inflating into `CRITICAL`/`YOU MUST` rhetoric.
- **Promote the universe rule.** Pulling "the combined list … is the universe" out of the parent prevents it from being read as a closing comment on whichever sub-source ran last.

## Scope and risk

- One bullet restructured inside one file. No other commands touched.
- All Layer 1 substring asserts in `tests/lint-prompts.test.js` are preserved: `.claude/agents/`, `frontmatter`, `YAML`, `plugin-name:`, the "Agent tool's description block" phrase, `**[Agent: ` marker.
- Prettier check on `commands/tasks.md` is clean.
- PR #113 (acceptance-criteria rules in `commands/spec.md`) is unaffected and unrelated; this fix is on its own branch off `main`.

## Test plan

- [x] Layer 1 substring asserts verified manually (no Node available locally; CI will re-confirm with `node --test`).
- [x] `bunx prettier --check commands/tasks.md` — clean.
- [x] Manual end-to-end: in `awos-qa`, run `bun run e2e:prepare tasks-discovers-plugin-agents` against this branch, then `claude "/awos:tasks 001-test-feature"` in the temp dir, then `bun run e2e:verify`. Expect all four contracts to pass (`.claude/agents/` scanned, `**[Agent: qa-stack:qa-python-specialist]**` and `**[Agent: qa-stack:qa-react-specialist]**` markers present in `tasks.md`, no hallucinated markers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated task-planning instructions for improved subagent discovery and assignment workflows. The system now explicitly requires delegating specialist-discovery reads to the Explore agent for enhanced capability detection and plugin discovery, while maintaining general-purpose as the reliable fallback for standard task scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/provectus/awos/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->