### PR TITLE
feat(implement): loop over every incomplete task by default

### DIFF
--- a/commands/implement.md
+++ b/commands/implement.md
@@ -36,21 +36,20 @@ Your goal is to execute the pending work for a given specification, one task at 
 
 Follow this process precisely. Steps 2–5 form the per-task loop: repeat them for each task in scope, in document order, until the scope is exhausted. Step 6 runs once after the loop.
 
-### Step 1: Identify the Target Specification and Scope
+### Step 1: Identify the Target Specification and Load Static Context
 
 1.  Analyze `<user_prompt>`. If it names a specific task, set scope to that single task in the spec it belongs to. If it names a spec (without a specific task), set the target spec from the prompt and set scope to "every incomplete (`[ ]`) task in that spec".
 2.  Otherwise (no prompt): scan `context/spec/` in order, find the first directory whose `tasks.md` has an incomplete item (`[ ]`), select it as the target spec, and set scope to "every incomplete task in that spec".
 3.  If no target can be determined (ambiguous prompt, or all tasks are done), tell the user and stop.
-
-### Step 2: Load Full Context and Pick the Next Task
-
-1.  On the first iteration, load all three context files in parallel:
+4.  Load the static spec context once, in parallel:
     - `[target-spec-directory]/functional-spec.md`
     - `[target-spec-directory]/technical-considerations.md`
-    - `[target-spec-directory]/tasks.md`
 
-    On later iterations, reload only `tasks.md` — the spec files don't change. Re-reading `tasks.md` each iteration ensures the next task is selected from the latest on-disk state.
+    These files don't change during the run; Step 3 embeds their content into the delegation prompt for every task.
 
+### Step 2: Read `tasks.md` and Pick the Next Task
+
+1.  Read `[target-spec-directory]/tasks.md`. Re-reading it each iteration ensures the next task is selected from the latest on-disk state.
 2.  Pick the next task in scope. If the user named a single task, that's the only task; once it's done the loop ends. Otherwise pick the first remaining `[ ]` task in document order from the freshly-read `tasks.md`. If no incomplete tasks remain, exit the loop and go to Step 6.
 3.  Extract the agent assignment from the selected task line:
     - Look for the `**[Agent: agent-name]**` pattern in the task line (e.g., `python-expert`, `react-expert`, `testing-expert`).
@@ -62,7 +61,7 @@ Follow this process precisely. Steps 2–5 form the per-task loop: repeat them f
 You do not write or edit code, configuration, or database schemas yourself. Your role is to delegate.
 
 1.  Construct a delegation prompt that includes:
-    - The full context from the three files loaded in Step 2.
+    - The full context from the three files loaded in Steps 1–2 (`functional-spec.md`, `technical-considerations.md`, `tasks.md`).
     - The specific task description.
     - Clear instructions on what code to write or files to modify.
     - A `<scope_discipline>` block: "Only make changes the task requires. Don't add features, refactor unrelated code, or add validation for scenarios outside the task. If something is unclear, ask rather than guessing."

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -10,7 +10,7 @@ You are a Lead Implementation Agent, acting as an AI Engineering Manager or a pr
 
 # TASK
 
-Your goal is to execute the next available task for a given specification. You will identify the target spec and task, load all necessary context, delegate the implementation to a coding subagent, and upon successful completion, mark the task as done in the `tasks.md` file.
+Your goal is to execute the pending work for a given specification, one task at a time, until the agreed scope is done. By default you loop through every incomplete task in the selected spec in document order; if the user names a single task, you execute only that one. For each task in scope you load context, re-extract its `**[Agent: name]**` marker, delegate to a coding subagent, and on success mark the task as done in `tasks.md` before moving to the next.
 
 ---
 
@@ -34,23 +34,28 @@ Your goal is to execute the next available task for a given specification. You w
 
 # PROCESS
 
-Follow this process precisely.
+Follow this process precisely. Steps 2–5 form the per-task loop: repeat them for each task in scope, in document order, until the scope is exhausted. Step 6 runs once after the loop.
 
-### Step 1: Identify the Target Specification and Task
+### Step 1: Identify the Target Specification and Scope
 
-1.  Analyze `<user_prompt>`. If it specifies a spec or task, use that to identify the target spec directory and/or task.
-2.  Otherwise: scan `context/spec/` in order, find the first directory whose `tasks.md` has an incomplete item (`[ ]`), and select the very first incomplete task there.
+1.  Analyze `<user_prompt>`. If it names a specific task, set scope to that single task in the spec it belongs to. If it names a spec (without a specific task), set the target spec from the prompt and set scope to "every incomplete (`[ ]`) task in that spec".
+2.  Otherwise (no prompt): scan `context/spec/` in order, find the first directory whose `tasks.md` has an incomplete item (`[ ]`), select it as the target spec, and set scope to "every incomplete task in that spec".
 3.  If no target can be determined (ambiguous prompt, or all tasks are done), tell the user and stop.
 
-### Step 2: Load Full Context and Extract Agent Assignment
+### Step 2: Load Full Context and Pick the Next Task
 
-1.  Load the three context files in parallel:
+1.  On the first iteration, load all three context files in parallel:
     - `[target-spec-directory]/functional-spec.md`
     - `[target-spec-directory]/technical-considerations.md`
     - `[target-spec-directory]/tasks.md`
-2.  Extract the agent assignment from the task description:
+
+    On later iterations, reload only `tasks.md` — the spec files don't change. Re-reading `tasks.md` each iteration ensures the next task is selected from the latest on-disk state.
+
+2.  Pick the next task in scope. If the user named a single task, that's the only task; once it's done the loop ends. Otherwise pick the first remaining `[ ]` task in document order from the freshly-read `tasks.md`. If no incomplete tasks remain, exit the loop and go to Step 6.
+3.  Extract the agent assignment from the selected task line:
     - Look for the `**[Agent: agent-name]**` pattern in the task line (e.g., `python-expert`, `react-expert`, `testing-expert`).
     - If no assignment is found, default to `general-purpose`.
+    - Each task is re-extracted independently — different tasks in the same spec can route to different specialists.
 
 ### Step 3: Delegate Implementation to a Subagent
 
@@ -76,17 +81,18 @@ You do not write or edit code, configuration, or database schemas yourself. Your
 
 - Wait for the subagent to complete its work and report a successful outcome. You should assume that a success signal from the subagent means the task was completed as instructed.
 
-### Step 5: Update Progress
+### Step 5: Update Progress and Loop
 
 1.  Read `tasks.md` from the target spec directory.
 2.  Find the line for the completed task. If it was a sub-item (indented checkbox under a parent), change only its `[ ]` → `[x]`. If, after that change, all sibling sub-items under the same parent are `[x]`, also mark the parent.
 3.  If the completed task was a top-level task, change its `[ ]` → `[x]`.
 4.  Save the modified content.
-5.  Report which task was marked done.
+5.  Report which task was marked done (one short line — keep per-task chatter terse so the full loop stays readable).
+6.  Return to Step 2 to pick up the next task in scope. If the subagent in Step 3 reported failure or was unable to finish, stop the loop here, surface what went wrong, and do not advance to the next task without user direction.
 
 ### Step 6: Announce Status
 
-Count completed `[x]` and total tasks, calculate percentage.
+After the loop exits, count completed `[x]` and total tasks in the target spec's `tasks.md` and calculate the percentage.
 
-- If tasks remain: "Implementation step complete. [N]/[Total] tasks done ([X]%)."
+- If tasks remain: "Implementation run complete. [N]/[Total] tasks done ([X]%)."
 - If all tasks are `[x]`: "All tasks complete (100%). Run `/awos:verify` to verify acceptance criteria and mark spec as Completed."

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -10,7 +10,7 @@ You are a Lead Implementation Agent, acting as an AI Engineering Manager or a pr
 
 # TASK
 
-Your goal is to execute the pending work for a given specification, one task at a time, until the agreed scope is done. By default you loop through every incomplete task in the selected spec in document order; if the user names a single task, you execute only that one. For each task in scope you load context, re-extract its `**[Agent: name]**` marker, delegate to a coding subagent, and on success mark the task as done in `tasks.md` before moving to the next.
+Your goal is to execute the pending work for a given specification until the agreed scope is done. The plan in `tasks.md` is organized as **slices** (vertical, end-to-end groupings) containing **tasks** (atomic units of work, each carrying a `**[Agent: name]**` marker). Tasks are the executable units — you delegate one task per subagent call. By default you loop through every incomplete task in the selected spec in document order; if the user names a single task, you execute only that one. For each task in scope you load context, re-extract its `**[Agent: name]**` marker, delegate to a coding subagent, and on success mark the task as done in `tasks.md` before moving to the next.
 
 ---
 
@@ -50,7 +50,7 @@ Follow this process precisely. Steps 2–5 form the per-task loop: repeat them f
 ### Step 2: Read `tasks.md` and Pick the Next Task
 
 1.  Read `[target-spec-directory]/tasks.md`. Re-reading it each iteration ensures the next task is selected from the latest on-disk state.
-2.  Pick the next task in scope. If the user named a single task, that's the only task; once it's done the loop ends. Otherwise pick the first remaining `[ ]` task in document order from the freshly-read `tasks.md`. If no incomplete tasks remain, exit the loop and go to Step 6.
+2.  Pick the next task in scope. Tasks are the nested checkbox lines under a slice header — they carry the `**[Agent: name]**` marker. Skip slice headers themselves (`- [ ] **Slice N: ...**`); they are composite groupings, not units of work. If the user named a single task, that's the only task; once it's done the loop ends. Otherwise pick the first remaining `[ ]` task in document order from the freshly-read `tasks.md`. If no incomplete tasks remain, exit the loop and go to Step 6.
 3.  Extract the agent assignment from the selected task line:
     - Look for the `**[Agent: agent-name]**` pattern in the task line (e.g., `python-expert`, `react-expert`, `testing-expert`).
     - If no assignment is found, default to `general-purpose`.
@@ -83,15 +83,15 @@ You do not write or edit code, configuration, or database schemas yourself. Your
 ### Step 5: Update Progress and Loop
 
 1.  Read `tasks.md` from the target spec directory.
-2.  Find the line for the completed task. If it was a sub-item (indented checkbox under a parent), change only its `[ ]` → `[x]`. If, after that change, all sibling sub-items under the same parent are `[x]`, also mark the parent.
-3.  If the completed task was a top-level task, change its `[ ]` → `[x]`.
+2.  Find the line for the completed task. If it was a task nested under a slice header, change only its `[ ]` → `[x]`. If, after that change, all sibling tasks under the same slice are `[x]`, also mark the slice header.
+3.  If the completed task wasn't grouped under a slice header (rare — the plan placed it at the top level), change its `[ ]` → `[x]`.
 4.  Save the modified content.
 5.  Report which task was marked done (one short line — keep per-task chatter terse so the full loop stays readable).
 6.  Return to Step 2 to pick up the next task in scope. If the subagent in Step 3 reported failure or was unable to finish, stop the loop here, surface what went wrong, and do not advance to the next task without user direction.
 
 ### Step 6: Announce Status
 
-After the loop exits, count completed `[x]` and total tasks in the target spec's `tasks.md` and calculate the percentage.
+After the loop exits, count completed `[x]` and total tasks in the target spec's `tasks.md` and calculate the percentage. Count only nested tasks (lines carrying `**[Agent: name]**` or otherwise under a slice header) — slice headers are composite and would double-count.
 
 - If tasks remain: "Implementation run complete. [N]/[Total] tasks done ([X]%)."
 - If all tasks are `[x]`: "All tasks complete (100%). Run `/awos:verify` to verify acceptance criteria and mark spec as Completed."

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -4,13 +4,15 @@ description: Breaks the Tech Spec into a task list for engineers.
 
 # ROLE
 
-You are an expert Tech Lead and software delivery planner. Your primary skill is breaking down complex feature specifications into a clear, actionable, and incremental task list. Your core philosophy is that the application **must remain in a runnable, working state after each task is completed**. You are an expert in "Vertical Slicing" and you will apply this principle to every task list you create.
+You are an expert Tech Lead and software delivery planner. Your primary skill is breaking down complex feature specifications into a clear, actionable, and incremental plan of slices and tasks. Your core philosophy is that the application **must remain in a runnable, working state after each slice is completed**. You are an expert in "Vertical Slicing" and you will apply this principle to every plan you create.
 
 ---
 
 # TASK
 
-Your goal is to create a markdown file with a comprehensive list of checkbox tasks for a given specification. You will identify the target spec, carefully analyze its functional and technical documents, and generate a task list where each main task represents a small, end-to-end, runnable increment of the feature. Every slice should contain test scenarios for subagents to verify that the slice is completed correctly. The final list will be saved to `tasks.md` within the spec's directory.
+Your goal is to create a markdown file with a comprehensive list of checkbox slices for a given specification. You will identify the target spec, carefully analyze its functional and technical documents, and generate a list where each slice represents a small, end-to-end, runnable increment of the feature, broken down into the atomic tasks needed to implement it. Every slice should contain test scenarios for subagents to verify that the slice is completed correctly. The final list will be saved to `tasks.md` within the spec's directory.
+
+A **slice** is the top-level grouping checkbox — a vertical, end-to-end runnable increment. It is composite and never executed directly. A **task** is the atomic nested checkbox under a slice — it carries a `**[Agent: agent-name]**` marker and is executed by exactly one subagent. `/awos:implement` iterates over tasks; when all tasks under a slice are `[x]`, the slice header is ticked too.
 
 ---
 
@@ -47,60 +49,60 @@ Follow this process precisely.
 
 - You will now generate the task list. You must adhere to the following critical rule.
 
-- **Rule: create runnable tasks using vertical slicing**
-  - A runnable task means that after the work is done the application can be started and used without errors, and a small piece of new functionality is visible or testable.
-  - Avoid horizontal, layer-based tasks (e.g., "Do all database work" then "Do all API work").
-  - Create vertical slices — the smallest end-to-end piece of functionality.
+- **Rule: build runnable slices from atomic tasks using vertical slicing**
+  - A runnable slice means that after the work under it is done the application can be started and used without errors, and a small piece of new functionality is visible or testable.
+  - Avoid horizontal, layer-based slices (e.g., "Do all database work" then "Do all API work").
+  - Create vertical slices — the smallest end-to-end pieces of functionality.
   - A slice is valid only if its functionality is verified by the agent using real tools (curl, shell, or a browser-automation MCP if the project has one configured).
   - Check that the project has the MCPs, services, and dependencies needed for testing each slice. If something is missing, instruct the user to install it.
   - If a slice cannot be tested, explain why and get user approval before proceeding.
   - A slice is not complete unless it is tested or the user has explicitly approved skipping the test.
 
-- **Your Thought Process for Generating Tasks:**
+- **Your Thought Process for Generating the Plan:**
   1.  First, identify the absolute smallest piece of user-visible value from the spec. This is your **Slice 1**.
   2.  Create a high-level checklist item for that slice (e.g., `- [ ] **Slice 1: View existing avatar (or placeholder)**`).
-  3.  Under that slice, create the nested sub-tasks (database, backend, frontend) needed to implement and verify **only that slice**.
-  4.  **For each sub-task, assign the appropriate subagent:**
-      - Identify the technology or domain the sub-task involves
+  3.  Under that slice, create the nested tasks (database, backend, frontend) needed to implement and verify **only that slice**.
+  4.  **For each task, assign the appropriate subagent:**
+      - Identify the technology or domain the task involves
       - Discover registered specialists from two sources, both routed through the built-in `Explore` agent: (a) scan `.claude/agents/*.md` and parse each agent's YAML frontmatter (`name`, `description`, `skills`) for project-local agents; (b) read the `Agent` tool's description block for plugin-provided agents (those whose `subagent_type` carries a `plugin-name:` prefix, e.g. `python-development:python-pro`). The combined list, plus the always-available built-in `general-purpose`, is the universe to match against — auto-dispatch metadata alone is not a substitute when the assignment must be definitive.
-      - Match the sub-task to a subagent based on:
+      - Match the task to a subagent based on:
         - Technology keywords
         - Task intent
         - Tech stack identified in technical-considerations.md
-      - Append the subagent assignment using format: `**[Agent: agent-name]**` at the end of the sub-task description
+      - Append the subagent assignment using format: `**[Agent: agent-name]**` at the end of the task description
       - Use `general-purpose` when no specialist clearly matches — track these for the Recommendations table
   5.  Next, identify the second-smallest piece of value that builds on the first. This is **Slice 2**.
-  6.  Create a high-level checklist item and its sub-tasks with subagent assignments.
+  6.  Create a high-level checklist item and its nested tasks with subagent assignments.
   7.  Repeat this process until all requirements from the specification are covered.
-  8.  For each slice's verification sub-task, identify required MCPs/services (browser MCP, curl, database access, etc.) and note any that may be missing.
+  8.  For each slice's verification task, identify required MCPs/services (browser MCP, curl, database access, etc.) and note any that may be missing.
 
 - **Example of applying the rule for "User Profile Picture Upload":**
-  - **Bad, Horizontal Tasks (DO NOT DO THIS):**
+  - **Bad, Horizontal Plan (DO NOT DO THIS):**
     - `[ ] Add avatar_url to users table`
     - `[ ] Create all avatar API endpoints (upload, delete)`
     - `[ ] Build the entire profile picture UI`
   - **Good, Vertical Slices with subagent assignments (DO THIS):**
     - `[ ] **Slice 1: Display a placeholder avatar on the profile page**`
-      - `[ ] Sub-task: Add a non-functional 'ProfileAvatar' UI component that shows a static placeholder image. **[Agent: react-expert]**`
-      - `[ ] Sub-task: Place the component on the profile page. **[Agent: react-expert]**`
+      - `[ ] Task: Add a non-functional 'ProfileAvatar' UI component that shows a static placeholder image. **[Agent: react-expert]**`
+      - `[ ] Task: Place the component on the profile page. **[Agent: react-expert]**`
     - `[ ] **Slice 2: Display the user's actual avatar if it exists**`
-      - `[ ] Sub-task: Add avatar_url column to the users table via a migration. **[Agent: python-expert]**`
-      - `[ ] Sub-task: Update the user API endpoint to return the avatar_url. **[Agent: python-expert]**`
-      - `[ ] Sub-task: Update the 'ProfileAvatar' component to fetch and display the user's avatar_url, falling back to the placeholder if null. **[Agent: react-expert]**`
-      - `[ ] Sub-task: Run the application. Use chrome MCP to connect the page in Browser. Verify that the profile page shows the correct avatar or placeholder. **[Agent: manual-qa-expert]**`
+      - `[ ] Task: Add avatar_url column to the users table via a migration. **[Agent: python-expert]**`
+      - `[ ] Task: Update the user API endpoint to return the avatar_url. **[Agent: python-expert]**`
+      - `[ ] Task: Update the 'ProfileAvatar' component to fetch and display the user's avatar_url, falling back to the placeholder if null. **[Agent: react-expert]**`
+      - `[ ] Task: Run the application. Use chrome MCP to connect the page in Browser. Verify that the profile page shows the correct avatar or placeholder. **[Agent: manual-qa-expert]**`
 
 ## Step 4: Present Draft and Refine
 
-- Present the complete, vertically sliced task list with subagent assignments to the user and ask for feedback.
-- Iterate until the user is satisfied (adjust, split, merge tasks, or reassign subagents as needed).
+- Present the complete, vertically sliced plan with subagent assignments to the user and ask for feedback.
+- Iterate until the user is satisfied (adjust, split, merge slices or tasks, or reassign subagents as needed).
 - If any tasks were assigned to `general-purpose` (because no specialist exists) or verification cannot be performed (missing MCPs/services), present a table:
 
   | Task/Slice            | Issue                                                    | Recommendation                                       |
   | --------------------- | -------------------------------------------------------- | ---------------------------------------------------- |
-  | Slice 2: Sub-task 3   | Assigned to `general-purpose` — no TypeScript specialist | Install `typescript-pro` agent for proper delegation |
+  | Slice 2: Task 3       | Assigned to `general-purpose` — no TypeScript specialist | Install `typescript-pro` agent for proper delegation |
   | Slice 3: Verification | Browser MCP not available                                | Install browser MCP to enable UI verification        |
 
 ## Step 5: File Generation
 
-1.  Write the final task list to `tasks.md` in the chosen spec directory.
+1.  Write the final slice/task list to `tasks.md` in the chosen spec directory.
 2.  Report the saved path and the next command: `/awos:implement`.

--- a/docs/commands/implement.md
+++ b/docs/commands/implement.md
@@ -21,7 +21,7 @@ The actual code changes are made by the specialist subagents it delegates to.
 2. **Loads full context**: Reads all three spec files (functional, technical, tasks) so the delegated agent has complete information.
 3. **Extracts agent assignment**: Reads the `**[Agent: agent-name]**` tag from the task description to determine which specialist to delegate to.
 4. **Delegates to subagent**: Sends a detailed prompt with full context and clear success criteria to the specialist agent (or `general-purpose` if no assignment found).
-5. **Updates progress**: Marks the completed task `[x]` in `tasks.md`. If all sub-tasks under a parent are done, marks the parent too.
+5. **Updates progress**: Marks the completed task `[x]` in `tasks.md`. If all tasks under a slice are done, marks the slice header too.
 6. **Reports status**: Shows completion percentage (e.g., "5/12 tasks done (42%)").
 
 ## Key behaviors
@@ -29,7 +29,7 @@ The actual code changes are made by the specialist subagents it delegates to.
 - **Strictly an orchestrator.** The implement command is prohibited from writing, editing, or modifying any production code, configuration files, or database schemas. It only delegates and tracks.
 - **Full context per delegation.** Each subagent receives the complete functional spec, technical spec, and task list — not just the task description. This ensures agents have all the context they need.
 - **Automatic task progression.** When run without arguments, it automatically finds and starts the next incomplete task.
-- **Parent/child task tracking.** When all sub-tasks under a parent are marked complete, the parent is automatically marked complete too.
+- **Slice/task tracking.** When all tasks under a slice are marked complete, the slice header is automatically marked complete too.
 
 ## Common misconceptions
 

--- a/docs/commands/tasks.md
+++ b/docs/commands/tasks.md
@@ -4,7 +4,7 @@
 
 ## What it does
 
-This command creates an actionable task list by breaking down the technical specification into small, incremental, end-to-end slices. Each task is assigned to a specialist subagent. It produces:
+This command creates an actionable plan by breaking down the technical specification into small, incremental, end-to-end **slices** (vertical groupings) and the atomic **tasks** that implement each slice. Each task is assigned to a specialist subagent. It produces:
 
 - `context/spec/[index]-[name]/tasks.md`
 
@@ -16,23 +16,24 @@ This command creates an actionable task list by breaking down the technical spec
 
 1. **Identifies the target spec**: Uses your prompt or asks you to choose from available specs.
 2. **Analyzes both specs**: Reads the functional and technical specifications to understand both "what" and "how".
-3. **Creates vertical slices**: Generates a list of tasks where each main task is a small, end-to-end piece of functionality — not a horizontal layer.
-4. **Assigns agents**: Each sub-task gets a specialist agent assignment (e.g., `**[Agent: python-expert]**`) based on the technology involved.
+3. **Creates vertical slices**: Generates a list where each slice is a small, end-to-end piece of functionality — not a horizontal layer.
+4. **Assigns agents**: Each task under a slice gets a specialist agent assignment (e.g., `**[Agent: python-expert]**`) based on the technology involved.
 5. **Adds verification steps**: Each slice includes test scenarios that agents must verify using real tools (browser MCP, curl, shell, etc.).
-6. **Presents for review**: Shows the full task list for your approval before saving.
+6. **Presents for review**: Shows the full slice/task list for your approval before saving.
 
 ## Key behaviors
 
-- **Vertical slicing is the core principle.** Each task delivers end-to-end functionality — database + API + UI together for one small feature. The application must remain runnable after each task.
-- **No horizontal tasks.** "Do all database work" followed by "Do all API work" is explicitly prohibited. Instead: "Slice 1: Display placeholder avatar" → "Slice 2: Upload and display real avatar".
-- **Agent assignment.** Every sub-task includes a `**[Agent: agent-name]**` tag. Tasks that don't match any specialist get assigned to `general-purpose`, with a recommendation table flagging these gaps.
+- **Vertical slicing is the core principle.** Each slice delivers end-to-end functionality — database + API + UI together for one small feature. The application must remain runnable after each slice is completed.
+- **Slices group tasks; tasks are atoms.** A slice is the vertical grouping header (composite, never executed directly). A task is the atomic unit under it, carrying a `**[Agent: name]**` marker and executed by one subagent.
+- **No horizontal slices.** "Do all database work" followed by "Do all API work" is explicitly prohibited. Instead: "Slice 1: Display placeholder avatar" → "Slice 2: Upload and display real avatar".
+- **Agent assignment.** Every task includes a `**[Agent: agent-name]**` tag. Tasks that don't match any specialist get assigned to `general-purpose`, with a recommendation table flagging these gaps.
 - **Testable slices.** Each slice must be verifiable. The command identifies required MCPs/services for testing and warns if any are missing.
 - **Incremental delivery.** After each slice is implemented, you should be able to start the app and see progress.
 
 ## Common misconceptions
 
-- **"Tasks should be organized by layer."** No. "All database migrations" then "all API endpoints" then "all UI components" is the horizontal anti-pattern. Each task should cut through all layers for one small feature.
-- **"Each task is a big feature."** Tasks should be the smallest possible end-to-end increment. If a task touches more than 2-3 files per layer, it's probably too big.
+- **"Slices should be organized by layer."** No. "All database migrations" then "all API endpoints" then "all UI components" is the horizontal anti-pattern. Each slice should cut through all layers for one small feature.
+- **"Each slice is a big feature."** Slices should be the smallest possible end-to-end increment. If a slice touches more than 2-3 files per layer, it's probably too big.
 - **"I can skip verification steps."** Verification is how agents confirm their work. Without it, bugs accumulate silently across slices.
 
 ## Example usage

--- a/plugins/awos/skills/ai-readiness-audit/dimensions/spec-driven-development.md
+++ b/plugins/awos/skills/ai-readiness-audit/dimensions/spec-driven-development.md
@@ -109,17 +109,17 @@ Audits whether the project uses AWOS for spec-driven development. AWOS provides 
 
 ### SDD-07: Tasks have meaningful agent assignments
 
-- **What:** Sub-tasks in tasks.md files are annotated with agent assignments using the AWOS format `**[Agent: agent-name]**`, and the majority of assignments are meaningful — specialist agents for implementation work, QA/tester agents for verification steps
+- **What:** Tasks nested under slice headers in tasks.md files are annotated with agent assignments using the AWOS format `**[Agent: agent-name]**`, and the majority of assignments are meaningful — specialist agents for implementation work, QA/tester agents for verification steps
 - **How:**
   1. Glob for all `context/spec/*/tasks.md` files
   2. For each tasks.md, grep for the pattern `\*\*\[Agent:.*\]\*\*` to find agent assignments
-  3. Count: total sub-task lines (lines matching `- \[ \]` or `- \[x\]` at indented level) vs sub-task lines with agent annotations
-  4. Calculate the annotation ratio: annotated sub-tasks / total sub-tasks
-  5. Extract all unique agent names. Occasional `general-purpose` assignments are fine for small utility tasks (commits, running linters, config tweaks) — only flag if the majority of implementation sub-tasks use `general-purpose`.
-  6. Check for domain mix-ups: frontend agents assigned to backend/database tasks or vice versa. Use keywords in the sub-task description to detect domain (e.g., "migration", "database", "API endpoint" → backend; "component", "UI", "page", "styling" → frontend).
-  7. Check that each slice's verification/testing sub-task is assigned to a QA/tester agent (e.g., `manual-qa-expert`, `testing-expert`, or similar) — not to the same agent that implemented the slice.
-- **Pass:** Majority of sub-tasks have agent assignments with no systematic domain mix-ups and verification tasks are assigned to QA/tester agents
-- **Warn:** Many sub-tasks lack annotations, OR most implementation tasks use `general-purpose`, OR verification tasks lack dedicated QA agent
+  3. Count: total task lines (indented checkbox lines `- \[ \]` / `- \[x\]` nested under a slice header) vs task lines with agent annotations. Older specs may use the legacy `Sub-task:` label — treat those identically.
+  4. Calculate the annotation ratio: annotated tasks / total tasks
+  5. Extract all unique agent names. Occasional `general-purpose` assignments are fine for small utility tasks (commits, running linters, config tweaks) — only flag if the majority of implementation tasks use `general-purpose`.
+  6. Check for domain mix-ups: frontend agents assigned to backend/database tasks or vice versa. Use keywords in the task description to detect domain (e.g., "migration", "database", "API endpoint" → backend; "component", "UI", "page", "styling" → frontend).
+  7. Check that each slice's verification/testing task is assigned to a QA/tester agent (e.g., `manual-qa-expert`, `testing-expert`, or similar) — not to the same agent that implemented the slice.
+- **Pass:** Majority of tasks have agent assignments with no systematic domain mix-ups and verification tasks are assigned to QA/tester agents
+- **Warn:** Many tasks lack annotations, OR most implementation tasks use `general-purpose`, OR verification tasks lack dedicated QA agent
 - **Fail:** No agent annotations at all, OR systematic domain mix-ups across multiple specs
 - **Skip-When:** SDD-01 is FAIL (AWOS not installed), or no tasks.md files exist (covered by SDD-05)
 - **Severity:** medium
@@ -135,5 +135,5 @@ When writing the dimension artifact, include this structured summary for downstr
 - **Spec status distribution:** N Draft, N In Review, N Approved, N Completed
 - **Stale specs:** N stale (list directory names)
 - **Spec-to-branch ratio:** N% of recent feature branches correlate with spec activity
-- **Agent coverage:** N% of sub-tasks have meaningful agent assignments
+- **Agent coverage:** N% of tasks have meaningful agent assignments
 ```


### PR DESCRIPTION
## Summary

- `/awos:implement` now loops through every incomplete task in the selected spec by default, instead of stopping after the first one — eliminating the "run the command N times" friction for multi-task specs.
- The single-task escape hatch is preserved: when the user names a specific task in `<user_prompt>`, scope is restricted to just that task. The orchestrator-only contract is unchanged — the loop is over delegations, not direct edits.
- Per-task `**[Agent: name]**` re-extraction is explicit, so different tasks in one spec can route to different specialists. `tasks.md` is re-read each iteration so the next task is selected from the latest on-disk state. On subagent failure the loop halts so the user can decide before more work is dispatched.

## Test plan

- [x] `bun test tests/` — 69 pass / 0 fail (static prompt linter contracts still hold: `**[Agent: ` reference, `<scope_discipline>`/`<investigate_before_answering>`/`<use_available_skills>` XML blocks, `Agent(subagent_type=` example, `# INTERACTION` + `AskUserQuestion`).
- [x] `bunx prettier . --check` — clean.
- [x] Behavioral end-to-end in [`awos-qa`](https://github.com/provectus/awos-qa): the `implement-orchestrator-only` scenario has been reworked into `implement-orchestrates-and-loops` (two slices, two distinct specialists, three new loop-specific assertions). Land that PR alongside this one; instructions for a manual run are in the scenario's `INSTRUCTIONS.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified implementation command to run tasks in an explicit per-task loop, re-read and mark tasks as completed, cascade slice/header completion, and report percent-complete status.
  * Formalized vertical “slices” as runnable end-to-end units with nested atomic tasks and required verification steps.
  * Specified agent assignment workflow (including specialist vs fallback) and verification/testing requirements per slice.
  * Updated guidance to assess agent coverage at the task/slice level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/provectus/awos/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->