### PR TITLE
feat: add scan codebase command for brownfield

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,11 @@ AWOS is **spec-driven** — all project state lives in markdown files under `con
 The canonical flow (each command is a markdown prompt under `commands/`):
 
 ```
-/awos:product → /awos:roadmap → /awos:architecture → /awos:hire
-              → /awos:spec → /awos:tech → /awos:tasks → /awos:implement → /awos:verify
+/awos:scan (brownfield only) → /awos:product → /awos:roadmap → /awos:architecture → /awos:hire
+                              → /awos:spec → /awos:tech → /awos:tasks → /awos:implement → /awos:verify
 ```
 
-The first four are run once at project setup; the last five iterate per feature. Each command reads/writes a specific document under `context/` (e.g. `context/product/product-definition.md`, `context/spec/NNN-feature/tasks.md`). The numeric prefix on spec directories is allocated by `scripts/create-spec-directory.sh`.
+`/awos:scan` runs once before product setup on brownfield projects to populate the knowledgebase. The next four commands are run once at project setup; the last five iterate per feature. Each command reads/writes a specific document under `context/` (e.g. `context/product/product-definition.md`, `context/spec/NNN-feature/tasks.md`). The numeric prefix on spec directories is allocated by `scripts/create-spec-directory.sh`.
 
 **Implementation delegation rule:** `/awos:implement` is an orchestrator only — it reads `tasks.md`, extracts the `**[Agent: name]**` marker from each task, and delegates to a subagent. The orchestrator is explicitly prohibited from editing code itself. Preserve this contract when editing `commands/implement.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,10 @@ The canonical flow (each command is a markdown prompt under `commands/`):
 
 ```
 /awos:scan (brownfield only) → /awos:product → /awos:roadmap → /awos:architecture → /awos:hire
-                              → /awos:spec → /awos:tech → /awos:tasks → /awos:implement → /awos:verify
+                              → /awos:spec → /awos:tech → /awos:tasks → /awos:implement → /awos:verify → /awos:archive
 ```
 
-`/awos:scan` runs once before product setup on brownfield projects to populate the knowledgebase. The next four commands are run once at project setup; the last five iterate per feature. Each command reads/writes a specific document under `context/` (e.g. `context/product/product-definition.md`, `context/spec/NNN-feature/tasks.md`). The numeric prefix on spec directories is allocated by `scripts/create-spec-directory.sh`.
+`/awos:scan` runs once before product setup on brownfield projects to populate the knowledgebase. The next four commands are run once at project setup; the last five iterate per feature. `/awos:archive` closes the loop after `/awos:verify` — it extracts learnings into the knowledgebase docs, logs the feature, and removes the spec directory. Each command reads/writes a specific document under `context/` (e.g. `context/product/product-definition.md`, `context/spec/NNN-feature/tasks.md`). The numeric prefix on spec directories is allocated by `scripts/create-spec-directory.sh`.
 
 **Implementation delegation rule:** `/awos:implement` is an orchestrator only — it reads `tasks.md`, extracts the `**[Agent: name]**` marker from each task, and delegates to a subagent. The orchestrator is explicitly prohibited from editing code itself. Preserve this contract when editing `commands/implement.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,11 @@ Each file in `claude/commands/{name}.md` is a tiny wrapper that points at `.awos
 
 ## Architecture: Document-Centric Workflow
 
-AWOS is **spec-driven** — all project state lives in markdown files under `context/` in the user's project, not in chat history. An AI agent can rehydrate full context by reading the files alone. The canonical flow (each command is a markdown prompt under `commands/`):
+AWOS is **spec-driven** — all project state lives in markdown files under `context/` in the user's project, not in chat history. An AI agent can rehydrate full context by reading the files alone.
+
+**Brownfield projects** can populate `context/spec/knowledgebase/` with two documents that give downstream commands awareness of the existing codebase: `structure.md` (directory layout, module boundaries, data flow) and `decisions.md` (non-standard project decisions that override or extend default agent behavior). These files are producer-agnostic — they can be populated by `/awos:scan` (codebase scan), `/awos:archive` (post-implementation learnings), or manually.
+
+The canonical flow (each command is a markdown prompt under `commands/`):
 
 ```
 /awos:product → /awos:roadmap → /awos:architecture → /awos:hire

--- a/README.md
+++ b/README.md
@@ -21,18 +21,19 @@ npx @provectusinc/awos
 
 This sets up the `.awos/` directory (commands, templates, scripts), the `.claude/commands/awos/` wrappers, and the `context/` directory where your project documents will live. It also registers the AWOS plugin marketplace in your project settings.
 
-> **Running on an existing codebase?** Start with an AI readiness audit to understand how AI-friendly your project is. Install the plugin with `/plugin install awos@awos-marketplace`, then run `/awos:ai-readiness-audit` to get a scored assessment with actionable recommendations for improvement. [Learn more](plugins/awos/README.md)
+> **Running on an existing codebase?** Run `/awos:scan` first to produce `context/spec/knowledgebase/` documents that give all downstream commands awareness of your existing codebase. Then continue with the foundation setup below. You can also run an AI readiness audit — install the plugin with `/plugin install awos@awos-marketplace`, then run `/awos:ai-readiness-audit`. [Learn more](plugins/awos/README.md)
 
 ### Step 2: Foundation Setup
 
 These commands establish your project's foundation. Run them once at the start, and re-run them as your project evolves — requirements change, architecture decisions get refined, and that's normal.
 
-| Command              | What it does                                                                      | Docs                                     |
-| -------------------- | --------------------------------------------------------------------------------- | ---------------------------------------- |
-| `/awos:product`      | Defines the Product — what, why, and for who.                                     | [Details](docs/commands/product.md)      |
-| `/awos:roadmap`      | Builds the Product Roadmap — features and their order.                            | [Details](docs/commands/roadmap.md)      |
-| `/awos:architecture` | Defines the System Architecture — stack, DBs, infra.                              | [Details](docs/commands/architecture.md) |
-| `/awos:hire`         | Hires specialist agents — finds, installs skills and MCPs, generates agent files. | [Details](docs/commands/hire.md)         |
+| Command              | What it does                                                                                  | Docs                                     |
+| -------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `/awos:scan`         | Scans existing codebase — produces structure and decisions documents for brownfield projects. | [Details](docs/commands/scan.md)         |
+| `/awos:product`      | Defines the Product — what, why, and for who.                                                 | [Details](docs/commands/product.md)      |
+| `/awos:roadmap`      | Builds the Product Roadmap — features and their order.                                        | [Details](docs/commands/roadmap.md)      |
+| `/awos:architecture` | Defines the System Architecture — stack, DBs, infra.                                          | [Details](docs/commands/architecture.md) |
+| `/awos:hire`         | Hires specialist agents — finds, installs skills and MCPs, generates agent files.             | [Details](docs/commands/hire.md)         |
 
 ### Step 3: Feature Development Cycle
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,16 @@ These commands establish your project's foundation. Run them once at the start, 
 
 Once your foundation is set, iterate through this cycle for each feature on your roadmap. These commands are designed to be run repeatedly — once per feature.
 
-> **Tip**: Don't hesitate to delete specs after implementation. Completed specs can become outdated and confuse the AI. Your code documentation is the source of truth.
+> **Tip**: Run `/awos:archive` after verifying a feature. It extracts learnings into the knowledgebase, logs the feature, and removes the spec directory so completed specs don't accumulate and confuse the AI.
 
-| Command           | What it does                                                                      | Docs                                  |
-| ----------------- | --------------------------------------------------------------------------------- | ------------------------------------- |
-| `/awos:spec`      | Creates the Functional Spec — what the feature does for the user.                 | [Details](docs/commands/spec.md)      |
-| `/awos:tech`      | Creates the Technical Spec — how the feature will be built.                       | [Details](docs/commands/tech.md)      |
-| `/awos:tasks`     | Breaks the Tech Spec into a task list for engineers.                              | [Details](docs/commands/tasks.md)     |
-| `/awos:implement` | Runs tasks — delegates coding to sub-agents, tracks progress.                     | [Details](docs/commands/implement.md) |
-| `/awos:verify`    | Verifies spec completion — checks acceptance criteria, marks Status as Completed. | [Details](docs/commands/verify.md)    |
+| Command           | What it does                                                                                  | Docs                                  |
+| ----------------- | --------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `/awos:spec`      | Creates the Functional Spec — what the feature does for the user.                             | [Details](docs/commands/spec.md)      |
+| `/awos:tech`      | Creates the Technical Spec — how the feature will be built.                                   | [Details](docs/commands/tech.md)      |
+| `/awos:tasks`     | Breaks the Tech Spec into a task list for engineers.                                          | [Details](docs/commands/tasks.md)     |
+| `/awos:implement` | Runs tasks — delegates coding to sub-agents, tracks progress.                                 | [Details](docs/commands/implement.md) |
+| `/awos:verify`    | Verifies spec completion — checks acceptance criteria, marks Status as Completed.             | [Details](docs/commands/verify.md)    |
+| `/awos:archive`   | Archives a completed spec — extracts learnings, logs the feature, removes the spec directory. | [Details](docs/commands/archive.md)   |
 
 > **When to skip the cycle**: Not every change needs a spec. Hotfixes, simple bugfixes, and small edits don't require the full spec workflow — Claude Code's built-in plan mode handles those just fine.
 

--- a/claude/commands/archive.md
+++ b/claude/commands/archive.md
@@ -1,0 +1,6 @@
+---
+description: Archives a completed spec — extracts learnings, logs the feature, removes the spec directory.
+argument-hint: '[spec name or index, optional]'
+---
+
+@.awos/commands/archive.md

--- a/claude/commands/scan.md
+++ b/claude/commands/scan.md
@@ -1,0 +1,6 @@
+---
+description: Scans existing codebase — produces structure and decisions documents for brownfield projects.
+argument-hint: '[scope path, optional]'
+---
+
+@.awos/commands/scan.md

--- a/commands/architecture.md
+++ b/commands/architecture.md
@@ -20,6 +20,7 @@ Your task is to manage the architecture file located at `context/product/archite
 - **Prerequisite Input 1:** `context/product/product-definition.md` (The "what" and "why").
 - **Prerequisite Input 2:** `context/product/roadmap.md` (The implementation phases).
 - **Primary Input/Output:** `context/product/architecture.md` (The file to create or update).
+- **Knowledgebase (Optional):** `context/spec/knowledgebase/structure.md` and `context/spec/knowledgebase/decisions.md` — if present, provide awareness of the existing codebase layout and non-standard project decisions that override or extend default agent behavior.
 
 ---
 
@@ -36,7 +37,8 @@ Follow this logic precisely.
 ### Step 1: Prerequisite Checks
 
 - If either `context/product/product-definition.md` or `context/product/roadmap.md` is missing, stop and tell the user to run `/awos:product` and `/awos:roadmap` first.
-- Otherwise, proceed to the next step.
+- If `context/spec/knowledgebase/structure.md` exists, read it to understand the existing project layout. The existing structure informs decisions, but architecture.md remains the sole authority on the technology stack.
+- Proceed to the next step.
 
 ### Step 2: Mode Detection
 

--- a/commands/archive.md
+++ b/commands/archive.md
@@ -1,0 +1,147 @@
+---
+description: Archives a completed spec — extracts learnings, logs the feature, removes the spec directory.
+---
+
+# ROLE
+
+You are a Knowledge Curator responsible for closing the spec-implement-verify loop. Your job is to extract lasting learnings from a completed specification into the project's shared context documents, log the feature for future reference, and remove the spec directory so it does not accumulate.
+
+---
+
+# TASK
+
+Archive a completed specification (Status: `Completed`). This involves four things: (1) use git history to discover what the implementation changed in the codebase, (2) update `context/spec/knowledgebase/` documents with new patterns and conventions introduced by the feature, (3) append a summary entry to `context/spec/feature-log.md`, and (4) delete the spec directory. Each knowledgebase doc and the feature log must stay under 500 lines.
+
+---
+
+# INPUTS & OUTPUTS
+
+- **User Prompt (Optional):** <user_prompt>$ARGUMENTS</user_prompt>
+- **Primary Context:** A spec directory under `context/spec/` containing:
+  - `functional-spec.md`
+  - `technical-considerations.md`
+  - `tasks.md`
+- **Knowledgebase (Optional):** `context/spec/knowledgebase/structure.md` and `context/spec/knowledgebase/decisions.md` — updated with learnings from the archived feature. If absent, knowledgebase updates are skipped.
+- **Feature Log:** `context/spec/feature-log.md` — appended with a summary of the archived feature. Created if it does not exist.
+- **Output:** Updated knowledgebase docs (if they existed), updated feature log, deleted spec directory.
+
+---
+
+# INTERACTION
+
+- Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
+---
+
+# PROCESS
+
+Follow this process precisely.
+
+### Step 1: Identify Target Specification
+
+1. Analyze `<user_prompt>`. If it names a spec by name or index (e.g., "archive 002" or "archive user-auth"), use that spec directory.
+2. Otherwise, find the first spec directory in `context/spec/` where `functional-spec.md` has Status: `Completed`.
+3. If no eligible spec is found, tell the user no completed specs are ready for archiving and stop.
+
+### Step 2: Load Context
+
+Read the following files in parallel:
+
+- `[target-spec-directory]/functional-spec.md`
+- `[target-spec-directory]/technical-considerations.md`
+- `[target-spec-directory]/tasks.md`
+- `context/spec/knowledgebase/structure.md` (if it exists)
+- `context/spec/knowledgebase/decisions.md` (if it exists)
+- `context/spec/feature-log.md` (if it exists)
+
+If neither knowledgebase doc exists, note that knowledgebase updates will be skipped — the feature log and spec cleanup still proceed.
+
+### Step 3: Git Archaeology
+
+Delegate to an `Explore` agent to discover the concrete changes the feature introduced to the codebase. The spec directory name contains the feature's short-name, which narrows the search.
+
+```text
+Agent(subagent_type="Explore", description="Trace feature git history", prompt="
+Find all commits related to the feature in this spec directory: [target-spec-directory].
+
+1. Run `git log --oneline -- [target-spec-directory]/` to find commits that touched the spec itself.
+2. For each commit found, run `git show --stat <hash>` to see which source files were modified in the same commit.
+3. Collect the unique set of source files changed across all commits (exclude context/ files).
+4. Run `git log --oneline -- <file1> <file2> ...` on those source files to find related implementation commits.
+5. For the most significant implementation commits (up to 10), run `git show --stat <hash>` to understand the scope of changes.
+
+Report:
+- The list of commits (hash + one-line message) in chronological order
+- The set of source files added or modified
+- New directories or modules created
+- Any new dependencies added (look for package.json, requirements.txt, build.gradle, go.mod changes)
+- New patterns introduced (new middleware, new test helpers, new utility modules)
+")
+```
+
+### Step 4: Extract and Merge Learnings
+
+Using the spec contents (Step 2) and the git archaeology findings (Step 3), determine what lasting information belongs in the knowledgebase docs. Skip this step entirely if no knowledgebase docs exist.
+
+For each doc, identify what the feature introduced:
+
+1. **`context/spec/knowledgebase/structure.md`** — New directories, modules, or architectural patterns. Changes to data flow or file placement rules.
+2. **`context/spec/knowledgebase/decisions.md`** — New non-standard decisions: coding patterns established by this feature, changes to error handling or testing strategy, new integration points, new constraints or tech debt introduced.
+
+Merge the new information into the appropriate sections of each doc. Do not duplicate what is already present. If the feature used existing patterns without introducing new ones, leave that doc unchanged.
+
+**500-line budget:** After merging, count the lines in each updated doc. If any exceeds 500 lines:
+
+- Combine entries that describe similar patterns into a single entry.
+- Remove redundant examples, keeping one representative per pattern.
+- Summarize older, well-established entries before trimming newly added ones — recent additions capture the latest state of the codebase.
+- Trim overly verbose descriptions to their essential content.
+
+### Step 5: Update Feature Log
+
+Append an entry to `context/spec/feature-log.md`. If the file does not exist, create it with the following header:
+
+```markdown
+# Feature Log
+
+Archived features and the capabilities they introduced. Read by `/awos:spec` and `/awos:tech` to find patterns available for reuse.
+
+---
+```
+
+Each feature entry follows this format:
+
+```markdown
+### [NNN] [Feature Name]
+
+- **Archived:** YYYY-MM-DD
+- **Summary:** [1-2 sentences — what the feature does for the user]
+- **Key additions:** [Components, patterns, modules introduced — e.g., "JWT auth middleware, user sessions table, login/register endpoints"]
+```
+
+Fill in the spec index number, the feature name from the spec title, today's date, and extract the summary and key additions from the spec contents and git archaeology.
+
+**500-line budget:** After appending, if the feature log exceeds 500 lines, collapse the oldest entries (lowest spec numbers) into a single summary section titled `### Legacy Features (001–NNN)` with one bullet per collapsed feature: `- **[NNN] [Name]:** [one-line summary]`. This preserves searchability while reducing line count.
+
+### Step 6: Write Updated Files
+
+Write only the files that changed:
+
+1. `context/spec/knowledgebase/structure.md` (if updated)
+2. `context/spec/knowledgebase/decisions.md` (if updated)
+3. `context/spec/feature-log.md`
+
+### Step 7: Confirm and Delete Spec Directory
+
+Before deleting, confirm with the user. Present the directory name and note that git history preserves the original files.
+
+If the user confirms, delete the entire `context/spec/[NNN-feature-name]/` directory.
+
+If the user declines, skip deletion — the feature log and knowledgebase updates are already saved.
+
+### Step 8: Report
+
+- Which knowledgebase docs were updated (one-line summary of what was added to each)
+- The feature-log entry that was appended
+- Whether the spec directory was deleted
+- Next command: `/awos:spec`

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -21,6 +21,7 @@ Your goal is to execute the pending work for a given specification until the agr
   - `functional-spec.md`
   - `technical-considerations.md`
   - `tasks.md`
+- **Knowledgebase (Optional):** `context/spec/knowledgebase/decisions.md` — if present, captures non-standard project decisions that override or extend default agent behavior.
 - **Primary Output:** An updated `tasks.md` file with a checkbox marked as complete.
 - **Action:** A call to a subagent to perform the actual coding.
 
@@ -62,6 +63,7 @@ You do not write or edit code, configuration, or database schemas yourself. Your
 
 1.  Construct a delegation prompt that includes:
     - The full context from the three files loaded in Steps 1–2 (`functional-spec.md`, `technical-considerations.md`, `tasks.md`).
+    - If `context/spec/knowledgebase/decisions.md` exists, include its content wrapped in `<project_decisions>` tags.
     - The specific task description.
     - Clear instructions on what code to write or files to modify.
     - A `<scope_discipline>` block: "Only make changes the task requires. Don't add features, refactor unrelated code, or add validation for scenarios outside the task. If something is unclear, ask rather than guessing."

--- a/commands/product.md
+++ b/commands/product.md
@@ -24,6 +24,7 @@ Your primary task is to **fill in** a product definition template using a guided
     ```
 2.  **Template File:** Use `.awos/templates/product-definition-template.md` as a template.
 3.  **Existing Definition (Optional):** The file `context/product/product-definition.md`, which, if present, triggers "Update Mode".
+4.  **Knowledgebase (Optional):** `context/spec/knowledgebase/structure.md` — if present, provides awareness of the existing codebase.
 
 ---
 
@@ -63,13 +64,14 @@ First, check if the file `context/product/product-definition.md` exists.
 ### Step 2B: Creation Mode
 
 1.  If `<user_prompt>` is non-empty, briefly note that you'll use it as a starting point, then refine from there.
-2.  Walk the user through the sections of the template, explaining each one.
+2.  If `context/spec/knowledgebase/structure.md` exists, read it. Summarize what already exists when presenting context to the user — this helps frame features relative to the current system.
+3.  Walk the user through the sections of the template, explaining each one.
     - **Project Name & Vision:** Ask for the project's name and its core purpose.
     - **Target Audience & Personas:** Ask who the product is for and help create one simple persona.
     - **Success Metrics:** Ask how they will measure the product's impact on the user.
     - **Core Features & User Journey:** Ask for the 3-5 most important high-level features and a simple user workflow.
     - **Project Boundaries:** Ask what is essential for the first version (In-Scope) and what can wait (Out-of-Scope).
-3.  Once all sections are complete, proceed to **Step 3: File Generation**.
+4.  Once all sections are complete, proceed to **Step 3: File Generation**.
 
 ---
 

--- a/commands/roadmap.md
+++ b/commands/roadmap.md
@@ -21,6 +21,7 @@ Your task is to manage the product roadmap file located at `context/product/road
 
 - **Template File:** `.awos/templates/roadmap-template.md`. This is the required structure for the roadmap.
 - **Prerequisite Input:** `context/product/product-definition.md`. This file MUST exist.
+- **Knowledgebase (Optional):** `context/spec/knowledgebase/structure.md` — if present, provides awareness of the existing codebase for brownfield planning.
 - **Primary Input/Output:** `context/product/roadmap.md`. This is the file you will create or update.
 
 ---
@@ -50,7 +51,7 @@ Follow this logic precisely.
 
 ## Scenario 1: Creation Mode
 
-1.  Read `context/product/product-definition.md` and the template at `.awos/templates/roadmap-template.md`.
+1.  Read `context/product/product-definition.md` and the template at `.awos/templates/roadmap-template.md`. If `context/spec/knowledgebase/structure.md` exists, read it too — existing capabilities inform phase sequencing.
 2.  Generate a proposed roadmap by populating the template structure with the product definition's Core Features, grouped into logical sequential phases.
 3.  Present the full draft to the user and ask for feedback.
 4.  Iterate until the user is satisfied, then proceed to **Step 3: Finalization**.

--- a/commands/scan.md
+++ b/commands/scan.md
@@ -1,0 +1,134 @@
+---
+description: Scans existing codebase — produces structure and decisions documents for brownfield projects.
+---
+
+# ROLE
+
+You are an expert Codebase Analyst. Your purpose is to explore an existing codebase and produce structured reference documents that capture its project structure and the non-standard decisions that shaped it. You are thorough, precise, and path-specific — every finding you record includes the exact file paths that evidence it.
+
+---
+
+# TASK
+
+Scan an existing codebase and produce two documents in `context/spec/knowledgebase/`: `structure.md` and `decisions.md`. These documents become the shared context that all downstream AWOS commands consume — they ground product definitions, architecture documents, and technical specs in the reality of the existing system. Determine whether to run in "Creation Mode" or "Update Mode" based on whether the scan documents already exist.
+
+---
+
+# INPUTS & OUTPUTS
+
+- **User Prompt (Optional):** <user_prompt>$ARGUMENTS</user_prompt>. Can scope the scan to a specific area (e.g., `src/api`) or request a full scan.
+- **Template 1:** `.awos/templates/structure-template.md`.
+- **Template 2:** `.awos/templates/decisions-template.md`.
+- **Existing Scan Docs (Optional):** `context/spec/knowledgebase/structure.md`, `context/spec/knowledgebase/decisions.md` — if present, triggers Update Mode.
+- **Output 1:** `context/spec/knowledgebase/structure.md` — project structure (directory layout, module boundaries, architectural patterns, data flow, file placement rules).
+- **Output 2:** `context/spec/knowledgebase/decisions.md` — non-standard project decisions (architecture patterns and why chosen, data flow boundaries, error handling strategy, testing strategy, integration points, known constraints).
+
+---
+
+# INTERACTION
+
+- Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
+---
+
+# PROCESS
+
+Follow this logic precisely.
+
+### Step 1: Mode Detection
+
+Check if both `context/spec/knowledgebase/structure.md` and `context/spec/knowledgebase/decisions.md` exist.
+
+- If **both exist**, proceed to **Step 2A: Update Mode**.
+- If **either is missing**, proceed to **Step 2B: Creation Mode**.
+
+---
+
+## Step 2A: Update Mode
+
+1. Read the existing `structure.md` and `decisions.md` from `context/spec/knowledgebase/` in parallel.
+2. Tell the user you found existing scan documents. Update Mode performs a full rescan — the existing documents are overwritten entirely.
+3. Proceed to **Step 3**.
+
+---
+
+## Step 2B: Creation Mode
+
+1. If `<user_prompt>` names a specific area, note you will focus on that area but still produce both documents.
+2. Proceed to **Step 3**.
+
+---
+
+### Step 3: Read Templates
+
+Read both templates in parallel:
+
+- `.awos/templates/structure-template.md`
+- `.awos/templates/decisions-template.md`
+
+---
+
+### Step 4: Launch Parallel Exploration
+
+Launch two `Explore` agents in parallel using the `Agent` tool. Each agent explores the codebase from a different perspective and returns its findings formatted according to its assigned template.
+
+If `<user_prompt>` specifies a scope (e.g., `src/api`), include that scope constraint in each agent's prompt.
+
+**Agent 1 — Structure Analysis:**
+
+```text
+Agent(subagent_type="Explore", description="Analyze project structure", prompt="
+Explore this codebase and document its structure. Be thorough and path-specific.
+
+Analyze:
+- Directory layout (top-level and one level deep, with purpose of each directory)
+- Module boundaries (what logical modules exist, their responsibilities, key entry files)
+- Architectural patterns (MVC, microservices, monorepo, event-driven, etc. — cite evidence)
+- Data flow (how a request/event moves through the system, from entry point to response)
+- File placement rules (where do new files of each type go — components, services, tests, configs)
+
+Format your response as a filled-in version of this template:
+
+[structure-template content here]
+")
+```
+
+**Agent 2 — Decisions Analysis:**
+
+```text
+Agent(subagent_type="Explore", description="Analyze project decisions", prompt="
+Explore this codebase and document the non-standard decisions that shaped it. Focus on WHY things were done a certain way, not just what exists. Be thorough and path-specific.
+
+Analyze:
+- Architecture patterns (what patterns were chosen and what constraints drove each decision — cite config files, directory structures, framework choices)
+- Data flow and state management (how data moves between layers, what state management approach is used and why — cite boundary files, middleware, stores)
+- Error handling strategy (how errors propagate through layers, boundary handling, logging approach — cite error handlers, middleware, logging config)
+- Testing strategy (what framework is used and why, where tests live relative to source, what gets mocked and what doesn't — cite test config, example test files)
+- Integration points (how modules and services communicate, API contracts, protocols — cite client code, config files, middleware)
+- Known constraints and tech debt (constraints that impact new work, deprecated patterns, TODO/FIXME/HACK comments, fragile areas — cite specific files)
+
+For each finding, explain the decision and its rationale — not just that a pattern exists, but why it was chosen over alternatives.
+
+Format your response as a filled-in version of this template:
+
+[decisions-template content here]
+")
+```
+
+**Embed the actual template content** (read in Step 3) into each agent's prompt where indicated. The template content replaces the `[*-template content here]` placeholders above.
+
+---
+
+### Step 5: Write Documents
+
+1. Create the `context/spec/knowledgebase/` directory if it does not exist.
+2. Write each agent's response to its corresponding file:
+   - Agent 1 response → `context/spec/knowledgebase/structure.md`
+   - Agent 2 response → `context/spec/knowledgebase/decisions.md`
+
+---
+
+### Step 6: Report
+
+1. Report the two saved paths.
+2. Next command: `/awos:product`.

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -30,6 +30,7 @@ Your primary task is to create a new functional specification file. You will det
 - **Template File:** `.awos/templates/functional-spec-template.md`.
 - **Context File 1:** `context/product/product-definition.md`.
 - **Context File 2:** `context/product/roadmap.md`.
+- **Knowledgebase (Optional):** `context/spec/knowledgebase/structure.md` — if present, provides awareness of existing features and capabilities.
 - **External Command:** `.awos/scripts/create-spec-directory.sh [short-name]`.
 - **Output File:** `context/spec/[index]-[short-name]/functional-spec.md`.
 

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -21,6 +21,7 @@ A **slice** is the top-level grouping checkbox — a vertical, end-to-end runnab
 - **User Prompt (Optional):** <user_prompt>$ARGUMENTS</user_prompt>
 - **Primary Context 1:** The `functional-spec.md` from the chosen spec directory.
 - **Primary Context 2:** The `technical-considerations.md` from the chosen spec directory.
+- **Knowledgebase (Optional):** `context/spec/knowledgebase/decisions.md` — if present, captures non-standard project decisions that override or extend default agent behavior. The Testing Strategy section informs verification tooling choices.
 - **Spec Directories:** Located under `context/spec/`.
 - **Output File:** `context/spec/[chosen-spec-directory]/tasks.md`.
 
@@ -45,7 +46,7 @@ Follow this process precisely.
 
 ## Step 2: Gather and Synthesize Context
 
-1.  Read and synthesize both `functional-spec.md` and `technical-considerations.md` from the chosen directory — issue the reads in parallel. You need to understand both the "what" and the "how."
+1.  Read and synthesize both `functional-spec.md` and `technical-considerations.md` from the chosen directory. If `context/spec/knowledgebase/decisions.md` exists, read it too — the Testing Strategy section informs verification tooling choices. Issue all reads in parallel. You need to understand both the "what" and the "how."
 
 ## Step 3: Plan and Draft the Task List
 

--- a/commands/tech.md
+++ b/commands/tech.md
@@ -20,6 +20,7 @@ Your primary task is to create the technical specification for a given feature. 
 - **Template File:** `.awos/templates/technical-considerations-template.md`.
 - **Primary Context 1:** The `functional-spec.md` from the chosen spec directory.
 - **Primary Context 2:** `context/product/architecture.md`.
+- **Knowledgebase (Optional):** `context/spec/knowledgebase/structure.md` and `context/spec/knowledgebase/decisions.md` — if present, provide awareness of the existing codebase layout and non-standard project decisions that override or extend default agent behavior.
 - **Additional Context:** The project's source code.
 - **Spec Directories:** Located under `context/spec/`.
 - **Output File:** The `technical-considerations.md` file inside the chosen spec directory.
@@ -44,7 +45,7 @@ Follow this process precisely.
 
 ### Step 2: Gather and Synthesize Context
 
-1.  Read the `functional-spec.md` from the chosen directory and the main `context/product/architecture.md`. These two inputs are independent — issue both `Read` calls in a single tool-use block (parallel tool calls). Sequence reads only when one's output feeds the next.
+1.  Read the `functional-spec.md` from the chosen directory and the main `context/product/architecture.md`. If `context/spec/knowledgebase/structure.md` or `context/spec/knowledgebase/decisions.md` exist, read them too. These inputs are independent — issue all `Read` calls in a single tool-use block (parallel tool calls). Sequence reads only when one's output feeds the next.
 2.  Identify candidate specialist subagents: determine which technology stack(s) this feature primarily involves (e.g., Python backend, React frontend, or both). Enumerate the universe of registered specialists by inspecting the `Agent` tool's description block in your own system prompt. This is an introspection step — no tool call is required, but it is mandatory. Both kinds of agents are listed there: project-local ones (declared as files under `.claude/agents/*.md`) and plugin-provided ones. Tell them apart by the `plugin-name:` prefix on `subagent_type` — plugin-provided agents carry it (e.g. `python-development:python-pro`, `backend-development:backend-architect`); project-local agents do not. Match each stack against this list, plus always-available built-ins (`general-purpose`, `Explore`, `Plan`).
 
 3.  Analyze the codebase: delegate the read-only exploration to the built-in `Explore` agent to keep the orchestrator context lean. If the feature spans multiple stacks, run one exploration per stack in parallel.

--- a/templates/decisions-template.md
+++ b/templates/decisions-template.md
@@ -1,0 +1,27 @@
+# Project Decisions
+
+## Architecture Patterns
+
+- **[Pattern]:** [Why chosen, what constraint drove this decision]
+
+## Data Flow & State
+
+- **[Boundary/Flow]:** [How data moves, state management approach, why]
+
+## Error Handling Strategy
+
+- **[Layer]:** [How errors propagate, boundary handling, logging approach]
+
+## Testing Strategy
+
+- **Framework:** [Name, config file, why chosen]
+- **Location:** [Where tests live relative to source]
+- **Mock Boundaries:** [What gets mocked, what doesn't, why]
+
+## Integration Points
+
+- **[Module/Service]:** [How it communicates, API contracts, protocols]
+
+## Known Constraints & Tech Debt
+
+- **[Area]:** [Constraint description, impact on new work]

--- a/templates/structure-template.md
+++ b/templates/structure-template.md
@@ -1,0 +1,21 @@
+# Project Structure
+
+## Directory Layout
+
+[Tree showing top-level directories with one-line purpose each]
+
+## Module Boundaries
+
+- **[Module]:** [Responsibility] — [Key entry files]
+
+## Architectural Patterns
+
+- **[Pattern]:** [Where used, how implemented]
+
+## Data Flow
+
+[How data moves through the system — request lifecycle, event flow, etc.]
+
+## File Placement Rules
+
+- [File type] goes in [directory] — [example]

--- a/tests/lint-prompts.test.js
+++ b/tests/lint-prompts.test.js
@@ -657,6 +657,36 @@ test('SDD-07 recognizes the dual-model QA coverage', () => {
   );
 });
 
+test('context/spec/knowledgebase/ references use only known filenames', () => {
+  // The knowledgebase contract defines exactly two files: structure.md and
+  // decisions.md. Any prompt that references context/spec/knowledgebase/
+  // must use one of these — a typo or renamed file would silently break
+  // the brownfield awareness chain.
+  const knownFiles = new Set(['structure.md', 'decisions.md']);
+  const dirs = [commandsDir, wrappersDir, templatesDir];
+  const violations = [];
+  for (const dir of dirs) {
+    for (const f of listMarkdown(dir)) {
+      const body = readUtf8(path.join(dir, f));
+      const matches =
+        body.match(/context\/spec\/knowledgebase\/[a-zA-Z0-9_.-]+\.md/g) || [];
+      for (const m of matches) {
+        const filename = m.split('/').pop();
+        if (!knownFiles.has(filename)) {
+          violations.push(
+            `${path.relative(repoRoot, path.join(dir, f))}: ${m}`
+          );
+        }
+      }
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    `knowledgebase references must use structure.md or decisions.md: ${violations.join(', ')}`
+  );
+});
+
 test('context/<path> references in prompts are internally consistent', () => {
   // Build a writer/reader map by scanning all prompts. A path is considered
   // consistent if every reference to it appears in at least one prompt — i.e.

--- a/tests/lint-prompts.test.js
+++ b/tests/lint-prompts.test.js
@@ -657,6 +657,35 @@ test('SDD-07 recognizes the dual-model QA coverage', () => {
   );
 });
 
+test('commands/scan.md has valid frontmatter and references both templates', () => {
+  const file = path.join(commandsDir, 'scan.md');
+  const body = readUtf8(file);
+  const { data, hasFrontmatter } = parse(body);
+  assert.ok(hasFrontmatter, 'commands/scan.md must have frontmatter');
+  assert.ok(
+    typeof data.description === 'string' && data.description.length > 0,
+    'commands/scan.md frontmatter must have a non-empty description'
+  );
+  assert.ok(
+    body.includes('.awos/templates/structure-template.md'),
+    'commands/scan.md must reference .awos/templates/structure-template.md'
+  );
+  assert.ok(
+    body.includes('.awos/templates/decisions-template.md'),
+    'commands/scan.md must reference .awos/templates/decisions-template.md'
+  );
+});
+
+test('scan templates exist in the templates directory', () => {
+  for (const name of ['structure-template.md', 'decisions-template.md']) {
+    const file = path.join(templatesDir, name);
+    assert.ok(
+      fs.existsSync(file),
+      `templates/${name} must exist — scan.md references it as .awos/templates/${name}`
+    );
+  }
+});
+
 test('context/spec/knowledgebase/ references use only known filenames', () => {
   // The knowledgebase contract defines exactly two files: structure.md and
   // decisions.md. Any prompt that references context/spec/knowledgebase/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `/awos:scan` command to document existing codebases, generating structure and decision records
  * All workflow commands now automatically detect and incorporate scan results for brownfield projects

* **Documentation**
  * Updated command guidance to differentiate brownfield vs. greenfield workflows
  * Expanded architecture documentation to emphasize decisions, infrastructure, security, and observability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->