### PR TITLE
/awos:* prompts gate the deliverable Write on AskUserQuestion approval, breaking `claude -p`

### DIFF
--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -29,6 +29,7 @@ A **slice** is the top-level grouping checkbox — a vertical, end-to-end runnab
 # INTERACTION
 
 - Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+- **A skipped or unanswered question — as happens in an unattended `claude -p` run — is never a stop signal. Fall back to the documented default for that question and continue through the remaining steps, including writing `tasks.md`.**
 
 ---
 
@@ -85,8 +86,9 @@ Skip this step if `SKIP_TESTS = true`.
     - The built-in `general-purpose` agent as the last resort.
 2.  **If no project-specific tester or AWOS testing agent is found,** stop and ask the user via `AskUserQuestion`. Present exactly three options:
     1.  **Install a testing agent now** — run `/awos:hire` to add `testing-expert` (or a more specific tester) from the registry, then re-run `/awos:tasks`.
-    2.  **Generate the slice with `general-purpose`** — proceed and produce the Feature Testing & Regression slice, marking its tasks `**[Agent: general-purpose]**`. Flag this in the Recommendations table.
+    2.  **Generate the slice with `general-purpose`** — proceed and produce the Feature Testing & Regression slice, marking its tasks `**[Agent: general-purpose]**`. Flag this in the Recommendations table. (Default when the question is skipped.)
     3.  **Skip the Feature Testing & Regression slice** — set `SKIP_TESTS = true` for this run only; the user can re-run `/awos:tasks` later once a tester is hired.
+
 3.  **Emit the slice** using the template below. Substitute `{qa-agent}` with the agent name selected above. Substitute `N` with the next slice number. Keep the wording — downstream automations depend on this exact structure.
 
     ```md
@@ -117,20 +119,20 @@ Skip this step if `SKIP_TESTS = true`.
       - `[ ] Read functional-spec.md acceptance criteria in full. Generate acceptance-level tests that verify the entire feature as a whole — not individual slices. Cover applicable layers (unit for pure logic, integration for service interactions, e2e for user flows) based on the project's testing stack. Write tests with RED validation (must fail before implementation is confirmed done). Annotate each test with @spec: [spec-directory] and @regression if suitable for long-term regression. **[Agent: testing-expert]**`
       - `[ ] Run all generated tests. All must pass. Fix any failures before proceeding. **[Agent: testing-expert]**`
 
-## Step 4: Present Draft and Refine
+## Step 4: Write the Task List
 
-- Present the complete, vertically sliced plan with subagent assignments to the user and ask for feedback.
-- Iterate until the user is satisfied (adjust, split, merge slices or tasks, or reassign subagents as needed).
-- If any tasks were assigned to `general-purpose` (because no specialist exists) or verification cannot be performed (missing MCPs/services), present a table:
-
-  | Task/Slice            | Issue                                                                               | Recommendation                                       |
-  | --------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- |
-  | Slice 2: Task 3       | Assigned to `general-purpose` — no TypeScript specialist                            | Install `typescript-pro` agent for proper delegation |
-  | Slice N (QA)          | Feature Testing & Regression slice uses `general-purpose` — no QA-coded agent hired | Run `/awos:hire` to install `testing-expert`         |
-  | Slice 3: Verification | Browser MCP not available                                                           | Install browser MCP to enable UI verification        |
-
-## Step 5: File Generation
-
-1.  Write the final slice/task list to `tasks.md` in the chosen spec directory.
+1.  Write the complete slice/task list to `tasks.md` in the chosen spec directory. **Write the file without waiting for approval** — generating a task list is reversible (re-run `/awos:tasks` to revise), so the deliverable must never be gated behind a confirmation that an unattended run cannot answer.
 2.  If `SKIP_TESTS = true`, record a one-line note at the top of the generated `tasks.md` so that downstream commands (e.g. `/awos:verify`) can detect the choice: `<!-- skip-tests: true -->`.
-3.  Report the saved path and the next command: `/awos:implement`.
+
+## Step 5: Surface for Review and Recommend Next Step
+
+1.  Report the saved path and present the slice/task plan for review. If the user requests changes (adjust, split, merge slices or tasks, or reassign subagents), apply them and re-save; otherwise they can revise later by re-running `/awos:tasks`.
+2.  If any tasks were assigned to `general-purpose` (because no specialist exists) or verification cannot be performed (missing MCPs/services), surface a table:
+
+    | Task/Slice            | Issue                                                                               | Recommendation                                       |
+    | --------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- |
+    | Slice 2: Task 3       | Assigned to `general-purpose` — no TypeScript specialist                            | Install `typescript-pro` agent for proper delegation |
+    | Slice N (QA)          | Feature Testing & Regression slice uses `general-purpose` — no QA-coded agent hired | Run `/awos:hire` to install `testing-expert`         |
+    | Slice 3: Verification | Browser MCP not available                                                           | Install browser MCP to enable UI verification        |
+
+3.  Report the next command: `/awos:implement`.

--- a/commands/tech.md
+++ b/commands/tech.md
@@ -29,6 +29,7 @@ Your primary task is to create the technical specification for a given feature. 
 # INTERACTION
 
 - Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+- **A skipped or unanswered question — as happens in an unattended `claude -p` run — is never a stop signal. Record your best-fit option as an explicit `**Assumption:**` in the draft and continue through the remaining steps, including writing the deliverable.**
 
 ---
 
@@ -79,14 +80,13 @@ Follow this process precisely.
     - Proactively identify potential issues and propose solutions.
     - Example: "A key risk here is handling large or malicious file uploads. I will add a 'Risk & Mitigation' note to include server-side validation of file type and size, and to process uploads asynchronously. Is there anything else we should be concerned about?"
 
-### Step 4: Final Review
+### Step 4: Write the Deliverable
 
-- Once you have collaboratively filled all sections of the template, present the complete draft to the user for a final review. Ask, "Here is the complete draft of the technical considerations. Please let me know if any changes are needed."
+Write the completed draft to the `technical-considerations.md` file inside the directory identified in Step 1. Write the file whether or not every question was answered — drafting a tech spec is reversible (re-run `/awos:tech` to revise), so the deliverable is never gated behind a confirmation an unattended run cannot answer.
 
-### Step 5: File Generation
+### Step 5: Surface for Review and Recommend Next Step
 
-1.  **Identify Path:** The output path is the `technical-considerations.md` file inside the directory you identified in Step 1.
-2.  **Save File:** Once the user approves the draft, write the final content into this file.
-3.  Review the saved spec for new technologies, frameworks, tools, or testing approaches not already covered by the project's existing architecture and specialist agents.
-    - If new capabilities are needed: report the saved path and recommend a pre-filled hire command: `/awos:hire cover [directory-name]: need [comma-separated list of new technologies/capabilities]`, followed by `/awos:tasks`.
-    - Otherwise: report the saved path and the next command: `/awos:tasks`.
+1.  Report the saved path. Surface any choices that were recorded as assumptions (rather than confirmed by the user) so they are easy to spot and challenge. If the user requests changes, apply them and re-save; otherwise they can revise later by re-running `/awos:tech` against the same spec.
+2.  Review the saved spec for new technologies, frameworks, tools, or testing approaches not already covered by the project's existing architecture and specialist agents.
+    - If new capabilities are needed: recommend a pre-filled hire command: `/awos:hire cover [directory-name]: need [comma-separated list of new technologies/capabilities]`, followed by `/awos:tasks`.
+    - Otherwise: report the next command: `/awos:tasks`.


### PR DESCRIPTION
Fixes #131.

## Problem

`/awos:tasks` and `/awos:tech` placed an `AskUserQuestion` approval gate *before* the deliverable `Write`. In unattended mode (`claude -p`) that question is silently dismissed: the orchestrator narrates "proceeding with defaults," but no `Write` is ever issued — the draft is printed as the final assistant text and the turn ends. Result: `tasks.md` / `technical-considerations.md` never land on disk, even when every other contract (specialist invoked, inputs read, no hallucinations) passes.

## Fix — issue Option 2 (preserve interactive UX; make the no-answer path write)

The right default is *ask first when a human is present; fall back to a documented assumption only when no one can answer.* So rather than dropping the questions, this makes a **skipped/unanswered question a signal to fall back and continue, never to stop** — and makes the deliverable `Write` unconditional.

- **Both commands** gain an `# INTERACTION` rule: a skipped or unanswered question (as in `claude -p`) is never a stop signal — record a documented assumption / default and continue through the remaining steps, including writing the deliverable.
- **`commands/tech.md`** — keeps the ask-first "assume but verify" drafting (consequential choices are still surfaced to a present user); reorders to `Draft → Write (unconditional) → Surface for review`. An unanswered per-section question is recorded as an explicit `**Assumption:**` and drafting continues.
- **`commands/tasks.md`** — the Step 3a QA-agent fallback no longer "stops and asks"; if unanswered it defaults to `general-purpose` (flagged in the Recommendations table) and continues. `File Generation` is split into `Write the Task List` (unconditional) + `Surface for Review`.

Out of scope: `/awos:spec` and `/awos:architecture` also gate writes, but their interactivity is legitimate (spec resolves `[NEEDS CLARIFICATION]` answers; architecture asks follow-ups) and they are not part of issue #131's acceptance criteria.

## Acceptance criteria

- [x] `claude -p "/awos:tasks <spec>"` writes `tasks.md` without operator interaction
- [x] `claude -p "/awos:tech <spec>"` writes `technical-considerations.md` without operator interaction
- [x] Interactive sessions still surface consequential choices for review before committing

## Testing

- `bun test tests/` — prompt-lint + installer + fixtures all pass; `prettier --check` clean
- awos-qa e2e (`bun run e2e:run`, real `claude -p` sessions) against the affected scenarios — see PR thread for the run output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Generate task plans immediately without requiring approval; allow an optional top-of-file marker to skip tests
  * Continue unattended runs when questions are skipped, recording clear “Assumption:” notes instead of stopping
  * Default QA agent set to general-purpose when tester prompts are unanswered; show recommendations table when needed
  * Save and report drafts with next-step command suggestions and surfaced assumptions for review
<!-- end of auto-generated comment: release notes by coderabbit.ai -->