### PR TITLE
fix(tasks): mark unreviewed tasks.md with a file-level marker, cleared on review

### DIFF
--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -122,12 +122,16 @@ Skip this step if `SKIP_TESTS = true`.
 ## Step 4: Write the Task List
 
 1.  Write the complete slice/task list to `tasks.md` in the chosen spec directory. **Write the file without waiting for approval** — generating a task list is reversible (re-run `/awos:tasks` to revise), so the deliverable must never be gated behind a confirmation that an unattended run cannot answer.
-2.  If `SKIP_TESTS = true`, record a one-line note at the top of the generated `tasks.md` so that downstream commands (e.g. `/awos:verify`) can detect the choice: `<!-- skip-tests: true -->`.
+2.  Record a one-line marker at the very top of the generated `tasks.md`: `<!-- not-user-reviewed -->`. The file is written before review (Step 5), so it starts as a draft; Step 5 removes this marker once the user has reviewed it. Keep the marker shape exactly — downstream automations grep for it to tell a draft from a reviewed plan.
+3.  If `SKIP_TESTS = true`, record a one-line note at the top of the generated `tasks.md` so that downstream commands (e.g. `/awos:verify`) can detect the choice: `<!-- skip-tests: true -->`.
 
 ## Step 5: Surface for Review and Recommend Next Step
 
-1.  Report the saved path and present the slice/task plan for review. If the user requests changes (adjust, split, merge slices or tasks, or reassign subagents), apply them and re-save; otherwise they can revise later by re-running `/awos:tasks`.
-2.  If any tasks were assigned to `general-purpose` (because no specialist exists) or verification cannot be performed (missing MCPs/services), surface a table:
+1.  Report the saved path and present the slice/task plan for review.
+2.  Ask for review feedback strictly via the `AskUserQuestion` tool (e.g. options "Looks good — keep it as saved" / "I want changes") — never in plain text, which would end a non-interactive turn before the review outcome can be reported.
+3.  **When the user responds** (either "looks good" or after you apply their requested changes and re-save): remove the `<!-- not-user-reviewed -->` marker from the top of `tasks.md`, since the plan has now been reviewed. If they requested changes, apply them — adjust, split, merge slices or tasks, or reassign subagents — and re-save before removing the marker.
+4.  **If the review question goes unanswered** (dismissed, or the run is non-interactive): leave the file exactly as saved, marker included. Its presence is the signal that the plan was written but not reviewed; do not remove it.
+5.  If any tasks were assigned to `general-purpose` (because no specialist exists) or verification cannot be performed (missing MCPs/services), surface a table:
 
     | Task/Slice            | Issue                                                                               | Recommendation                                       |
     | --------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- |
@@ -135,4 +139,4 @@ Skip this step if `SKIP_TESTS = true`.
     | Slice N (QA)          | Feature Testing & Regression slice uses `general-purpose` — no QA-coded agent hired | Run `/awos:hire` to install `testing-expert`         |
     | Slice 3: Verification | Browser MCP not available                                                           | Install browser MCP to enable UI verification        |
 
-3.  Report the next command: `/awos:implement`.
+6.  Report the next command: `/awos:implement`.

--- a/tests/lint-prompts.test.js
+++ b/tests/lint-prompts.test.js
@@ -554,6 +554,24 @@ test('commands/tasks.md documents the skip-tests opt-out and persists it', () =>
   );
 });
 
+test('commands/tasks.md marks an unreviewed tasks.md and clears it on review', () => {
+  // tasks.md is written before review (Step 4), so it starts as a
+  // draft carrying a "<!-- not-user-reviewed -->" marker that Step 5
+  // removes once the user reviews it. The marker shape is the contract
+  // — awos-qa greps the saved file to tell a draft from a reviewed
+  // plan, so a reword here would silently break that detection. Lock
+  // the shape, plus the removal-on-review instruction.
+  const body = readUtf8(path.join(commandsDir, 'tasks.md'));
+  assert.ok(
+    body.includes('<!-- not-user-reviewed -->'),
+    'commands/tasks.md must record the literal "<!-- not-user-reviewed -->" marker so awos-qa can detect a draft-grade tasks.md'
+  );
+  assert.ok(
+    /remove the `<!-- not-user-reviewed -->` marker/i.test(body),
+    'commands/tasks.md Step 5 must remove the not-user-reviewed marker once the plan has been reviewed'
+  );
+});
+
 test('commands/verify.md acknowledges the skip-tests marker', () => {
   // The Slack thread feedback frames /awos:verify as look-and-feel +
   // spec-freshness rather than a test runner. The skip-tests marker


### PR DESCRIPTION
Closes #135.

> **Scope note:** #135's headline ask — write-then-review so the deliverable survives a headless turn — already landed in #132. This PR closes the residual gap: a saved `tasks.md` that nobody reviewed was indistinguishable from a reviewed one.

## Change

A file-level marker on `tasks.md`, mirroring the existing `<!-- skip-tests: true -->` contract:

- **Step 4** writes `<!-- not-user-reviewed -->` at the top of `tasks.md`. The file is written before review, so it starts as a draft.
- **Step 5** removes the marker once the user reviews the plan — on approval, or after their requested changes are applied and re-saved. If the review question is dismissed or the run is non-interactive, the marker stays; its presence is the draft signal.
- Review feedback is asked **strictly via `AskUserQuestion`**, never plain text (a plain-text ask ends a non-interactive turn before the review outcome can be recorded).

### Why a file marker (this PR's earlier revision used a chat-report line)

Per review feedback, the marker moved from the final chat report into the saved file. A file-level HTML-comment marker is pure ASCII (no fragile em-dash join key), persisted in the artifact, **grep-detectable deterministically** instead of parsed from freeform chat, and visible to anyone opening the file later. It's the same mechanism `/awos:verify` already relies on for `<!-- skip-tests: true -->`.

## Test (Layer 1)

New `tests/lint-prompts.test.js` case locks both the marker shape and the removal-on-review instruction — per `CLAUDE.md`, a grep-catchable contract ships its test in the same PR (the adjacent `skip-tests` marker is locked the same way). `npm run test:lint` → 32/32.

## Validation (live, claude 2.1.175, effort medium, branch on current main)

Both contract branches exercised end-to-end via the awos-qa harness:

| Branch | Setup | tasks.md marker | verify |
|---|---|---|---|
| Headless / no review | `claude -p`, review question dismissed | **present** (Claude left it, citing the rule) | 4/4 pass |
| Review approved | approval answered via a `PreToolUse` answer-map hook | **removed** (0 occurrences) | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Surface for Review and Recommend Next Step” workflow to collect all review feedback exclusively via the AskUserQuestion tool. Added draft-state handling using a `<!-- not-user-reviewed -->` marker that is removed only after a completed review, while unanswered/dismissed reviews preserve the draft marker and reflect that status in the final report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->