### PR TITLE
fix: write product/roadmap deliverable on an unanswered question

### DIFF
--- a/commands/architecture.md
+++ b/commands/architecture.md
@@ -27,6 +27,9 @@ Your task is to manage the architecture file located at `context/product/archite
 # INTERACTION
 
 - Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+- A skipped or unanswered question is never a stop signal. Fall back to the documented default for that question and continue through the remaining steps, including writing `context/product/architecture.md`.
+
+<!-- Editor note (not an instruction): this rule is necessary but not sufficient. In `claude -p` a dismissed AskUserQuestion ends the turn, so a deliverable Write placed after such a question never runs unattended. The fix is structural — keep the Write ahead of any dismissable question, then refine afterward. -->
 
 ---
 
@@ -76,16 +79,13 @@ Follow this logic precisely.
     ")
     ```
 
-    c. Triage new findings with the user. Group related findings by category and use `AskUserQuestion` to batch up to four per call. For each finding, offer **Accept** and **Reject** as options. The user can also select "Other" to provide free-text feedback — treat it according to intent (correction, substitution, partial accept, or any other reaction). Discard rejected findings. Append accepted and corrected findings to `context/product/brownfield.md` under a `## Technology` heading. For corrected findings, record the corrected version, not the original.
+    c. Append the new findings to `context/product/brownfield.md` under a `## Technology` heading (for any you revise, record the revised version, not the original). The findings seed the section defaults below and are triaged with the user later, in **Step 3: Finalization** — after the architecture is saved — so exploration never blocks the write.
 
-    d. Use the confirmed technology findings as the default for each section, but still walk every section with the user. The interview still covers every area; the exploration gives better defaults, not fewer questions.
-
-3.  Work through the template section by section — not all at once.
+3.  Draft every architectural area up front so a complete architecture exists before any back-and-forth — never blocking on a question before the write.
     - For each architectural area, propose a concrete title from the template placeholder.
-    - For each component, propose a specific technology with one or more alternatives, justified by the project context. When brownfield findings provided a known technology, present it as the default.
-    - If the user is unsure, ask clarifying questions about team skills, budget, or priorities. Do not proceed until the current section is confirmed.
-    - Repeat for every architectural area (Data, Infrastructure, etc.).
-4.  Once all sections are confirmed, proceed to **Step 3: Finalization**.
+    - For each component, propose a specific technology with one or more alternatives, justified by the project context. When brownfield findings provided a known technology, use it as the default; otherwise pick a sensible best-practice default and label it as an assumption.
+    - Cover every architectural area (Data, Infrastructure, etc.).
+4.  Proceed to **Step 3: Finalization**.
 
 ---
 
@@ -101,8 +101,9 @@ Follow this logic precisely.
 
 ### Step 3: Finalization
 
-1.  Write the final content to `context/product/architecture.md`.
-2.  Proceed to **Step 4: Coverage Hint**.
+1.  Write the architecture content to `context/product/architecture.md`. **Write the file without waiting for approval** — an architecture is reversible (re-run `/awos:architecture` to revise), so the deliverable is never gated behind a confirmation an unattended run cannot answer.
+2.  Present the saved architecture for review. If brownfield technology findings seeded any defaults, triage them with the user now: use `AskUserQuestion` to offer **Accept** and **Reject** for each (the user can also select "Other" for free-text feedback — treat it according to intent), and for any rejected or corrected choice update `context/product/architecture.md` and re-save. Apply any other requested changes and re-save; otherwise the user can revise later by re-running `/awos:architecture`.
+3.  Proceed to **Step 4: Coverage Hint**.
 
 ---
 

--- a/commands/product.md
+++ b/commands/product.md
@@ -66,7 +66,13 @@ First, check if the file `context/product/product-definition.md` exists.
 
 ### Step 2B: Creation Mode
 
-1.  **Brownfield detection.** Check whether the project already has source code by looking for common indicators (`src/`, `app/`, `lib/`, `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `Gemfile`, `build.gradle`, `*.csproj`, `Makefile`, `CMakeLists.txt`, `setup.py`, `pyproject.toml`, or similar). If any are found, ask the user whether to run codebase exploration using `AskUserQuestion` with two options: **Yes, explore the codebase** ("Use existing code as context for the product definition") and **No, start from scratch** ("Treat this as a new project — ignore existing code"). If the user chooses to skip or the question goes unanswered, proceed to step 2 as if no source code was found. Otherwise, run a comprehensive exploration before drafting:
+1.  **Brownfield decision.** Decide whether to use existing source code as context, in this order — and never block the write on the choice:
+
+    a. **Prompt intent first.** Read `<user_prompt>`. If it clearly asks to use or explore the existing codebase (e.g. "explore existing code", "use the current codebase", "brownfield"), the decision is **explore**. If it clearly opts out (e.g. "without brownfield detection", "from scratch", "ignore existing code", "greenfield"), the decision is **skip**. Interpret intent with natural-language understanding, not substring matching — "don't explore the codebase" is a **skip**, not an explore. When the prompt states a preference, act on it and do not ask.
+
+    b. **Silent prompt.** If `<user_prompt>` says nothing either way, check whether the project already has source code by looking for common indicators (`src/`, `app/`, `lib/`, `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `Gemfile`, `build.gradle`, `*.csproj`, `Makefile`, `CMakeLists.txt`, `setup.py`, `pyproject.toml`, or similar). If none are found, the decision is **skip**. If any are found, ask the user with `AskUserQuestion` — **Yes, explore the codebase** ("Use existing code as context for the product definition") and **No, start from scratch** ("Treat this as a new project — ignore existing code"). This question is reached only in an interactive run whose prompt expressed no preference; an unattended run states its choice in the prompt.
+
+2.  **If the decision is explore,** run a comprehensive exploration before drafting:
 
     a. Launch an `Explore` agent focused on the product domain:
 
@@ -82,17 +88,15 @@ First, check if the file `context/product/product-definition.md` exists.
     ")
     ```
 
-    b. Triage findings with the user. Group related findings by category (e.g. all features in one call, audience signals in another) and use `AskUserQuestion` to batch up to four per call. For each finding, offer **Accept** and **Reject** as options. The user can also select "Other" to provide free-text feedback — treat it according to intent (correction, substitution, partial accept, or any other reaction). Discard rejected findings.
+    b. Create `context/product/brownfield.md` with a `## Product` heading and record the findings under it. If the exploration surfaced nothing, still create the file with an empty `## Product` section; downstream commands (`/awos:roadmap`, `/awos:architecture`) key on the file's existence to run their own explorations. The findings are triaged with the user later, in **Step 4** — after the definition is saved — so exploration never blocks the write.
 
-    c. Create `context/product/brownfield.md` with a `## Product` heading. List all accepted and corrected findings under it — for corrected findings, record the corrected version, not the original. If every finding was rejected or the exploration surfaced nothing, still create the file with an empty `## Product` section; downstream commands (`/awos:roadmap`, `/awos:architecture`) key on the file's existence to run their own explorations.
-
-2.  Draft every section of the template up front so a complete definition exists before any further back-and-forth — use `<user_prompt>` (when non-empty) as the starting point, fold in any brownfield findings from step 1, and fill the rest from reasonable best-practice assumptions. Never block on a question before the write:
+3.  Draft every section of the template up front so a complete definition exists before any further back-and-forth — use `<user_prompt>` (when non-empty) as the starting point, fold in any brownfield findings from step 2, and fill the rest from reasonable best-practice assumptions. Never block on a question before the write:
     - **Project Name & Vision:** the project's name and its core purpose.
     - **Target Audience & Personas:** who the product is for, plus one simple persona.
     - **Success Metrics:** how the product's impact on the user is measured.
     - **Core Features & User Journey:** the 3-5 most important high-level features and a simple user workflow.
     - **Project Boundaries:** what is essential for the first version (In-Scope) and what can wait (Out-of-Scope).
-3.  Proceed to **Step 3: File Generation**. The draft is saved there and refined with the user in **Step 4**, so it lands on disk even when no one is available to answer questions.
+4.  Proceed to **Step 3: File Generation**. The draft is saved there and refined with the user in **Step 4**, so it lands on disk even when no one is available to answer questions.
 
 ---
 
@@ -105,5 +109,7 @@ First, check if the file `context/product/product-definition.md` exists.
 
 ### Step 4: Refine and Recommend Next Step
 
-1.  Present the saved definition and offer to refine it — ask which sections to adjust, then apply changes and re-save. If no answer comes (e.g. an unattended `claude -p` run), leave the assumption-based draft in place; the user can revise later by re-running `/awos:product`.
-2.  Report the saved path and the next command: `/awos:roadmap`.
+1.  Present the saved definition and offer to refine it — ask which sections to adjust, then apply changes and re-save.
+2.  **If `context/product/brownfield.md` was created in Step 2,** triage its findings with the user now. Group related findings by category and use `AskUserQuestion` to batch up to four per call, offering **Accept** and **Reject** for each (the user can also select "Other" for free-text feedback — treat it according to intent). Remove rejected findings from `context/product/brownfield.md` and from the saved definition, and re-save both; for corrected findings, record the corrected version.
+3.  If no answer comes (e.g. an unattended `claude -p` run), leave the saved definition and findings in place; the user can revise later by re-running `/awos:product`.
+4.  Report the saved path and the next command: `/awos:roadmap`.

--- a/commands/product.md
+++ b/commands/product.md
@@ -37,6 +37,9 @@ Your primary task is to **fill in** a product definition template using a guided
 # INTERACTION
 
 - Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+- A skipped or unanswered question is never a stop signal. Fall back to a documented default or assumption for that question and continue through the remaining steps, including writing `context/product/product-definition.md`.
+
+<!-- Editor note (not an instruction): this rule is necessary but not sufficient. In `claude -p` a dismissed AskUserQuestion ends the turn, so a deliverable Write placed after such a question never runs unattended. The fix is structural — keep the Write ahead of any dismissable question, then refine afterward. -->
 
 ---
 
@@ -63,7 +66,7 @@ First, check if the file `context/product/product-definition.md` exists.
 
 ### Step 2B: Creation Mode
 
-1.  **Brownfield detection.** Check whether the project already has source code by looking for common indicators (`src/`, `app/`, `lib/`, `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `Gemfile`, `build.gradle`, `*.csproj`, `Makefile`, `CMakeLists.txt`, `setup.py`, `pyproject.toml`, or similar). If any are found, ask the user whether to run codebase exploration using `AskUserQuestion` with two options: **Yes, explore the codebase** ("Use existing code as context for the product definition") and **No, start from scratch** ("Treat this as a new project — ignore existing code"). If the user chooses to skip, proceed to step 2 as if no source code was found. Otherwise, run a comprehensive exploration before starting the interview:
+1.  **Brownfield detection.** Check whether the project already has source code by looking for common indicators (`src/`, `app/`, `lib/`, `package.json`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pom.xml`, `Gemfile`, `build.gradle`, `*.csproj`, `Makefile`, `CMakeLists.txt`, `setup.py`, `pyproject.toml`, or similar). If any are found, ask the user whether to run codebase exploration using `AskUserQuestion` with two options: **Yes, explore the codebase** ("Use existing code as context for the product definition") and **No, start from scratch** ("Treat this as a new project — ignore existing code"). If the user chooses to skip or the question goes unanswered, proceed to step 2 as if no source code was found. Otherwise, run a comprehensive exploration before drafting:
 
     a. Launch an `Explore` agent focused on the product domain:
 
@@ -83,19 +86,24 @@ First, check if the file `context/product/product-definition.md` exists.
 
     c. Create `context/product/brownfield.md` with a `## Product` heading. List all accepted and corrected findings under it — for corrected findings, record the corrected version, not the original. If every finding was rejected or the exploration surfaced nothing, still create the file with an empty `## Product` section; downstream commands (`/awos:roadmap`, `/awos:architecture`) key on the file's existence to run their own explorations.
 
-2.  If `<user_prompt>` is non-empty, briefly note that you'll use it as a starting point, then refine from there.
-3.  Walk the user through the sections of the template. When step 1 produced brownfield findings, use the Product section to propose draft answers — frame questions as "does this match what you intend, or would you change it?" rather than asking from a blank slate. The interview still covers every section; the exploration gives better defaults, not fewer questions.
-    - **Project Name & Vision:** Ask for the project's name and its core purpose.
-    - **Target Audience & Personas:** Ask who the product is for and help create one simple persona.
-    - **Success Metrics:** Ask how they will measure the product's impact on the user.
-    - **Core Features & User Journey:** Ask for the 3-5 most important high-level features and a simple user workflow.
-    - **Project Boundaries:** Ask what is essential for the first version (In-Scope) and what can wait (Out-of-Scope).
-4.  Once all sections are complete, proceed to **Step 3: File Generation**.
+2.  Draft every section of the template up front so a complete definition exists before any further back-and-forth — use `<user_prompt>` (when non-empty) as the starting point, fold in any brownfield findings from step 1, and fill the rest from reasonable best-practice assumptions. Never block on a question before the write:
+    - **Project Name & Vision:** the project's name and its core purpose.
+    - **Target Audience & Personas:** who the product is for, plus one simple persona.
+    - **Success Metrics:** how the product's impact on the user is measured.
+    - **Core Features & User Journey:** the 3-5 most important high-level features and a simple user workflow.
+    - **Project Boundaries:** what is essential for the first version (In-Scope) and what can wait (Out-of-Scope).
+3.  Proceed to **Step 3: File Generation**. The draft is saved there and refined with the user in **Step 4**, so it lands on disk even when no one is available to answer questions.
 
 ---
 
 ### Step 3: File Generation
 
-1.  Populate the template from `.awos/templates/product-definition-template.md` with the gathered information.
-2.  Write the final content to `context/product/product-definition.md`.
-3.  Report the saved path and the next command: `/awos:roadmap`.
+1.  Populate the template from `.awos/templates/product-definition-template.md` with the drafted content, labeling any section filled from an assumption rather than a user answer.
+2.  Write the content to `context/product/product-definition.md`. **Write the file without waiting for approval** — a product definition is reversible (re-run `/awos:product` to revise), so the deliverable is never gated behind a confirmation an unattended run cannot answer.
+
+---
+
+### Step 4: Refine and Recommend Next Step
+
+1.  Present the saved definition and offer to refine it — ask which sections to adjust, then apply changes and re-save. If no answer comes (e.g. an unattended `claude -p` run), leave the assumption-based draft in place; the user can revise later by re-running `/awos:product`.
+2.  Report the saved path and the next command: `/awos:roadmap`.

--- a/commands/roadmap.md
+++ b/commands/roadmap.md
@@ -29,6 +29,9 @@ Your task is to manage the product roadmap file located at `context/product/road
 # INTERACTION
 
 - Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+- A skipped or unanswered question is never a stop signal. Fall back to the documented default for that question and continue through the remaining steps, including writing `context/product/roadmap.md`.
+
+<!-- Editor note (not an instruction): this rule is necessary but not sufficient. In `claude -p` a dismissed AskUserQuestion ends the turn, so a deliverable Write placed after such a question never runs unattended. The fix is structural — keep the Write ahead of any dismissable question, then refine afterward. -->
 
 ---
 
@@ -80,8 +83,7 @@ Follow this logic precisely.
     d. Use the full set of confirmed capabilities (from brownfield.md) to anchor the roadmap: existing capabilities are noted as already done, and new phases focus on what comes next. Feed this into the roadmap generation in the next step.
 
 3.  Generate a proposed roadmap by populating the template structure with the product definition's Core Features, grouped into logical sequential phases.
-4.  Present the full draft to the user and ask for feedback.
-5.  Iterate until the user is satisfied, then proceed to **Step 3: Finalization**.
+4.  Proceed to **Step 3: Finalization** — the draft is saved there and then surfaced for review, so it lands on disk even when no one is available to give feedback.
 
 ---
 
@@ -97,5 +99,6 @@ Follow this logic precisely.
 
 ### Step 3: Finalization
 
-1.  Write the final roadmap content to `context/product/roadmap.md`.
-2.  Report the saved path and the next command: `/awos:architecture`.
+1.  Write the roadmap content to `context/product/roadmap.md`. **Write the file without waiting for approval** — a roadmap is reversible (re-run `/awos:roadmap` to revise), so the deliverable is never gated behind a confirmation an unattended run cannot answer.
+2.  Report the saved path, then present the roadmap for review. If the user requests changes, apply them and re-save; otherwise they can revise later by re-running `/awos:roadmap`.
+3.  Report the next command: `/awos:architecture`.

--- a/commands/roadmap.md
+++ b/commands/roadmap.md
@@ -78,9 +78,9 @@ Follow this logic precisely.
     ")
     ```
 
-    c. Triage new findings with the user. Group related findings by category and use `AskUserQuestion` to batch up to four per call. For each finding, offer **Accept** and **Reject** as options. The user can also select "Other" to provide free-text feedback — treat it according to intent (correction, substitution, partial accept, or any other reaction). Discard rejected findings. Append accepted and corrected findings to `context/product/brownfield.md` under a `## Capabilities` heading. For corrected findings, record the corrected version, not the original.
+    c. Append the new findings to `context/product/brownfield.md` under a `## Capabilities` heading (for any you revise, record the revised version, not the original). The findings are triaged with the user later, in **Step 3: Finalization** — after the roadmap is saved — so exploration never blocks the write.
 
-    d. Use the full set of confirmed capabilities (from brownfield.md) to anchor the roadmap: existing capabilities are noted as already done, and new phases focus on what comes next. Feed this into the roadmap generation in the next step.
+    d. Use the full set of capabilities (from brownfield.md) to anchor the roadmap: existing capabilities are noted as already done, and new phases focus on what comes next. Feed this into the roadmap generation in the next step.
 
 3.  Generate a proposed roadmap by populating the template structure with the product definition's Core Features, grouped into logical sequential phases.
 4.  Proceed to **Step 3: Finalization** — the draft is saved there and then surfaced for review, so it lands on disk even when no one is available to give feedback.
@@ -100,5 +100,5 @@ Follow this logic precisely.
 ### Step 3: Finalization
 
 1.  Write the roadmap content to `context/product/roadmap.md`. **Write the file without waiting for approval** — a roadmap is reversible (re-run `/awos:roadmap` to revise), so the deliverable is never gated behind a confirmation an unattended run cannot answer.
-2.  Report the saved path, then present the roadmap for review. If the user requests changes, apply them and re-save; otherwise they can revise later by re-running `/awos:roadmap`.
+2.  Report the saved path, then present the roadmap for review. If brownfield capabilities were appended in Creation Mode, triage them with the user now: use `AskUserQuestion` to offer **Accept** and **Reject** for each (the user can also select "Other" for free-text feedback — treat it according to intent). Remove rejected findings from `context/product/brownfield.md`, re-anchor the roadmap if needed, and re-save. If the user requests other changes, apply them and re-save; otherwise they can revise later by re-running `/awos:roadmap`.
 3.  Report the next command: `/awos:architecture`.

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -38,6 +38,9 @@ Your primary task is to create a new functional specification file. You will det
 # INTERACTION
 
 - Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+- A skipped or unanswered question is never a stop signal. Mark the unresolved detail with a `[NEEDS CLARIFICATION: …]` marker and continue through the remaining steps, including writing `functional-spec.md`.
+
+<!-- Editor note (not an instruction): this rule is necessary but not sufficient. In `claude -p` a dismissed AskUserQuestion ends the turn, so a deliverable Write placed after such a question never runs unattended. The fix is structural — keep the Write ahead of any dismissable question, then refine afterward. -->
 
 ---
 
@@ -75,7 +78,7 @@ Your first goal is to determine the **topic** - the single, specific feature or 
 - **Non-Technical Questions Only:** Your questions must be answerable by a product manager or designer — never ask about data models, API design, storage, architecture, state management, caching, or any implementation detail. Frame every question in terms of what the user sees, does, or experiences. If you need to understand a behavior, ask "What should the user see when…?" not "How should the system handle…?"
 - **Never Surface Technical Names:** When you encounter technical identifiers (field names, API response keys, database columns, type names, etc.) in context files, silently map them to plain-language labels. Do not ask the user to confirm whether a user-facing label corresponds to a technical field name. If you are unsure what a technical term means in user-facing language, ask "What does the user call [plain description of the concept]?" — never expose the raw identifier.
 - **Self-Check Before Every Question:** Re-read your question. If it contains a code identifier (camelCase, snake_case, PascalCase, or a name that only appears in source code / API schemas), rewrite the question without it. If the question cannot be asked without referencing the identifier, it is a technical question — drop it.
-- You will now fill the template section by section, but you must actively probe for details that are not yet documented.
+- You will now draft the specification, section by section, from the context in Step 2. Probe for the details each section needs, but do not block on questions: where an answer is not already documented, capture the question inline as a `[NEEDS CLARIFICATION: …]` marker and keep drafting. You resolve these markers with the user in **Step 6**, after the spec is saved — so an unattended run still produces a complete draft. The examples below show the depth of probing to aim for.
 
 1.  **Overview and Rationale (The "Why"):**
     - Use the information extracted about your **topic** from Step 2 as the foundation.
@@ -86,7 +89,7 @@ Your first goal is to determine the **topic** - the single, specific feature or 
     - Ask the user to describe what needs to be done from a user's perspective.
     - For every piece of information the user gives you, think like a tester and clarify ambiguities. If the user answers in technical terms, rewrite the information into plain, user-facing language before including it in the spec.
     - If the user says: "The user needs to be able to upload a profile picture."
-    - You MUST ask clarifying questions like: "Great. Let's break that down. What file formats should be allowed (e.g., JPG, PNG)? Is there a maximum file size? What should happen after the upload is successful? What specific error message should the user see if it fails?"
+    - Probe with clarifying questions like: "Great. Let's break that down. What file formats should be allowed (e.g., JPG, PNG)? Is there a maximum file size? What should happen after the upload is successful? What specific error message should the user see if it fails?" — for any that stay unanswered, leave a `[NEEDS CLARIFICATION: …]` marker rather than stopping.
     - If information is missing, mark every unresolved detail with `[NEEDS CLARIFICATION: your specific question]` directly in the draft. Example: "The user should see an error message. [NEEDS CLARIFICATION: What should the exact text of the error message be?]"
 
 3.  **Acceptance Criteria:**
@@ -107,13 +110,13 @@ Your first goal is to determine the **topic** - the single, specific feature or 
 
 - Before presenting to the user, re-read the entire draft end-to-end. For every sentence, ask: "Would this make sense to someone who has never seen the codebase?" Replace any developer-facing language with plain, non-technical wording in the same language the user is using. Remove any references to internal system behavior, code, or architecture that slipped in.
 
-### Step 5: Final Review
+### Step 5: File Generation
 
-- Present the complete, populated template to the user for a final review. Ask, "Here is the complete draft of the functional specification. Please review it for any inaccuracies or missing details."
-
-### Step 6: File Generation
-
-1.  **Create Short Name:** Once the user approves the draft, generate a short, kebab-case name from the specification's title (e.g., "User Profile Picture Upload" becomes `user-profile-picture-upload`).
+1.  **Create Short Name:** Generate a short, kebab-case name from the specification's title (e.g., "User Profile Picture Upload" becomes `user-profile-picture-upload`).
 2.  **Execute Directory Script:** Execute the shell script with the short name as a parameter: `.awos/scripts/create-spec-directory.sh [short-name]`. This will create a new directory (e.g., `context/spec/001-user-profile-picture-upload`).
-3.  **Save the File:** Write the final, approved specification content into the `functional-spec.md` file within the newly created directory.
-4.  Report the saved path and the next command: `/awos:tech`.
+3.  **Save the File:** Write the specification content into the `functional-spec.md` file within the newly created directory. **Write the file without waiting for approval** — a spec is reversible (re-run `/awos:spec` to revise) and any open questions are already captured as `[NEEDS CLARIFICATION: …]` markers in the draft, so the deliverable is never gated behind a confirmation an unattended run cannot answer.
+
+### Step 6: Final Review and Recommend Next Step
+
+1.  Present the saved specification and ask the user to review it for inaccuracies or missing details. Resolve any `[NEEDS CLARIFICATION: …]` markers with them, apply edits, and re-save. If no answer comes (e.g. an unattended `claude -p` run), leave the markers in place; the user — or `/awos:tech` — can resolve them later.
+2.  Report the saved path and the next command: `/awos:tech`.

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -29,7 +29,9 @@ A **slice** is the top-level grouping checkbox — a vertical, end-to-end runnab
 # INTERACTION
 
 - Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
-- **A skipped or unanswered question — as happens in an unattended `claude -p` run — is never a stop signal. Fall back to the documented default for that question and continue through the remaining steps, including writing `tasks.md`.**
+- A skipped or unanswered question is never a stop signal. Fall back to the documented default for that question and continue through the remaining steps, including writing `tasks.md`.
+
+<!-- Editor note (not an instruction): this rule is necessary but not sufficient. In `claude -p` a dismissed AskUserQuestion ends the turn, so a deliverable Write placed after such a question never runs unattended. The fix is structural — keep the Write ahead of any dismissable question, then refine afterward. -->
 
 ---
 

--- a/commands/tech.md
+++ b/commands/tech.md
@@ -29,7 +29,9 @@ Your primary task is to create the technical specification for a given feature. 
 # INTERACTION
 
 - Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
-- **A skipped or unanswered question — as happens in an unattended `claude -p` run — is never a stop signal. Record your best-fit option as an explicit `**Assumption:**` in the draft and continue through the remaining steps, including writing the deliverable.**
+- **A skipped or unanswered question is never a stop signal. Record your best-fit option as an explicit `**Assumption:**` in the draft and continue through the remaining steps, including writing the deliverable.**
+
+<!-- Editor note (not an instruction): this rule is necessary but not sufficient. In `claude -p` a dismissed AskUserQuestion ends the turn, so a deliverable Write placed after such a question never runs unattended. The fix is structural — keep the Write ahead of any dismissable question, then refine afterward. -->
 
 ---
 

--- a/tests/lint-prompts.test.js
+++ b/tests/lint-prompts.test.js
@@ -413,15 +413,16 @@ test('deliverable commands write their file on an unanswered question', () => {
   // unanswered question as a signal to fall back to a default and still write
   // the file — never as a stop. See commands/tasks.md for the canonical rule.
   //
-  // This list is intentionally partial: spec.md is also a
-  // document-generating command and still carries the same unfixed approval
-  // gate (e.g. spec.md "Once the user approves the draft … write the
-  // specification"). It is a deliberate follow-up — add it here once the
-  // same fallback rule is ported to it.
+  // Every command that generates a document under context/ and asks the
+  // user questions on the way carries this rule. spec.md's default is its
+  // own `[NEEDS CLARIFICATION: …]` marker rather than a documented value,
+  // but the contract is the same: an unanswered question is never a stop —
+  // record the gap and still write the deliverable.
   const deliverableCommands = [
     'product.md',
     'roadmap.md',
     'architecture.md',
+    'spec.md',
     'tasks.md',
     'tech.md',
   ];

--- a/tests/lint-prompts.test.js
+++ b/tests/lint-prompts.test.js
@@ -404,6 +404,43 @@ test('every core command declares an INTERACTION section', () => {
   );
 });
 
+test('deliverable commands write their file on an unanswered question', () => {
+  // These document-generating commands ask the user questions and then
+  // write a file. In an unattended `claude -p` run those questions are
+  // silently dismissed; without an explicit fallback the command narrates a
+  // draft and ends the turn, so the deliverable never lands on disk. Each
+  // listed command must carry the INTERACTION rule that treats a skipped or
+  // unanswered question as a signal to fall back to a default and still write
+  // the file — never as a stop. See commands/tasks.md for the canonical rule.
+  //
+  // This list is intentionally partial: spec.md and architecture.md are also
+  // document-generating commands and still carry the same unfixed approval
+  // gate (e.g. spec.md "Once the user approves the draft … write the
+  // specification"). They are a deliberate follow-up — add them here once the
+  // same fallback rule is ported to them.
+  const deliverableCommands = [
+    'product.md',
+    'roadmap.md',
+    'tasks.md',
+    'tech.md',
+  ];
+  const missing = [];
+  for (const c of deliverableCommands) {
+    const body = readUtf8(path.join(commandsDir, c));
+    if (
+      !body.includes('never a stop signal') ||
+      !body.includes('including writing')
+    ) {
+      missing.push(c);
+    }
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    `deliverable commands missing the unattended-write fallback rule ("never a stop signal" + "including writing"): ${missing.join(', ')}`
+  );
+});
+
 test('wrappers do not duplicate the AskUserQuestion rule', () => {
   // Counterpart to the test above: the rule moved from wrappers to
   // core. If a wrapper still mentions AskUserQuestion the contract has

--- a/tests/lint-prompts.test.js
+++ b/tests/lint-prompts.test.js
@@ -413,14 +413,15 @@ test('deliverable commands write their file on an unanswered question', () => {
   // unanswered question as a signal to fall back to a default and still write
   // the file — never as a stop. See commands/tasks.md for the canonical rule.
   //
-  // This list is intentionally partial: spec.md and architecture.md are also
-  // document-generating commands and still carry the same unfixed approval
+  // This list is intentionally partial: spec.md is also a
+  // document-generating command and still carries the same unfixed approval
   // gate (e.g. spec.md "Once the user approves the draft … write the
-  // specification"). They are a deliberate follow-up — add them here once the
-  // same fallback rule is ported to them.
+  // specification"). It is a deliberate follow-up — add it here once the
+  // same fallback rule is ported to it.
   const deliverableCommands = [
     'product.md',
     'roadmap.md',
+    'architecture.md',
     'tasks.md',
     'tech.md',
   ];

--- a/tests/lint-prompts.test.js
+++ b/tests/lint-prompts.test.js
@@ -425,13 +425,13 @@ test('deliverable commands write their file on an unanswered question', () => {
     'tech.md',
   ];
   const missing = [];
-  for (const c of deliverableCommands) {
-    const body = readUtf8(path.join(commandsDir, c));
+  for (const command of deliverableCommands) {
+    const body = readUtf8(path.join(commandsDir, command));
     if (
       !body.includes('never a stop signal') ||
       !body.includes('including writing')
     ) {
-      missing.push(c);
+      missing.push(command);
     }
   }
   assert.deepEqual(


### PR DESCRIPTION
## What & why

`/awos:product` and `/awos:roadmap` gated their deliverable file write behind interactive Q&A. In an unattended `claude -p` run the questions are silently dismissed, so neither command ever wrote its file — the draft was printed as the final assistant text and the turn ended, and `context/product/product-definition.md` / `context/product/roadmap.md` never landed on disk.

This is the same bug already fixed for `/awos:tasks` and `/awos:tech` in #131, which was never propagated to these two commands. Observed before the fix: roadmap prosed and never wrote in 6/6 `-p` runs; product prosed interactively.

## The fix

A dismissed `AskUserQuestion` in `-p` mode **ends the turn**, so any question asked *before* the write blocks the deliverable. The fix removes the pre-write questioning and makes the write unconditional, then refines interactively afterward — #131's "Option 2": keep the interactive UX, make the no-answer path still write.

- Add the INTERACTION rule to both commands: a skipped/unanswered question (e.g. in `claude -p`) is never a stop signal — fall back to a documented default/assumption and continue through the file write.
- **roadmap.md**: Creation Mode hands straight to Finalization; Finalization writes `roadmap.md` unconditionally, then surfaces it for review.
- **product.md**: Creation Mode drafts every section up front from the prompt and best-practice assumptions (no blocking question), Step 3 writes the file without waiting for approval, and a new Step 4 refines it with the user *after* it exists.
- Lock the contract with a Layer 1 lint test asserting the deliverable commands (product, roadmap, tasks, tech) carry the unattended-write fallback rule. Its comment notes that `spec.md` / `architecture.md` still have the same latent gate and are a deliberate follow-up.

## Verification

- Full suite green: `npm test` — 79 pass, 0 fail (includes the new lint test).
- `npx prettier . --check` clean.
- **Behavioral E2E** (new scenarios in awos-qa, run with `claude -p` against this branch): both pass 2/2 — the file is written and populated unattended. The first product attempt (INTERACTION rule only) failed the E2E because it still asked before writing; that's what drove the write-first restructure. See the companion PR: provectus/awos-qa#29.

## Scope note

Intentionally limited to product + roadmap (the reported regression). `spec.md` and `architecture.md` carry the same unfixed gate and are flagged in the test comment for a follow-up PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product, roadmap, architecture, and spec drafting now continues when questions are skipped/unanswered, using documented defaults/assumptions and producing complete drafts upfront.
  * During unattended runs, deliverables are written immediately, then presented for review with later refinement possible by re-running the relevant command.

* **Bug Fixes**
  * Skipped/unanswered questions are no longer treated as stop signals.
  * Unresolved items are marked for clarification and persist if no response arrives.

* **Documentation**
  * Updated workflow guidance to ensure deliverable writing occurs before any dismissible prompts in unattended execution.

* **Tests**
  * Added a lint test verifying deliverable commands include “never a stop signal” and “including writing” guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->