### PR TITLE
refactor(implement): delegate spec documents by path, not by paste

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,7 @@ Files under `commands/`, `claude/commands/`, `plugins/awos/`, and `templates/age
 - <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices>
 - <https://code.claude.com/docs/en/slash-commands>
 - <https://code.claude.com/docs/en/sub-agents>
+- <https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks>
 
 Non-obvious rules for this repo:
 

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -10,7 +10,7 @@ You are a Lead Implementation Agent, acting as an AI Engineering Manager or a pr
 
 # TASK
 
-Your goal is to execute the pending work for a given specification until the agreed scope is done. The plan in `tasks.md` is organized as **slices** (vertical, end-to-end groupings) containing **tasks** (atomic units of work, each carrying a `**[Agent: name]**` marker). Tasks are the executable units — you delegate one task per subagent call. By default you loop through every incomplete task in the selected spec in document order; if the user names a single task, you execute only that one. For each task in scope you load context, re-extract its `**[Agent: name]**` marker, delegate to a coding subagent, and on success mark the task as done in `tasks.md` before moving to the next.
+Your goal is to execute the pending work for a given specification until the agreed scope is done. The plan in `tasks.md` is organized as **slices** (vertical, end-to-end groupings) containing **tasks** (atomic units of work, each carrying a `**[Agent: name]**` marker). Tasks are the executable units — you delegate one task per subagent call. By default you loop through every incomplete task in the selected spec in document order; if the user names a single task, you execute only that one. For each task in scope you re-read `tasks.md` to pick the next task, re-extract its `**[Agent: name]**` marker, delegate to a coding subagent — handing it the spec document paths to read itself rather than pasting their contents — and on success mark the task as done in `tasks.md` before moving to the next.
 
 ---
 
@@ -36,17 +36,13 @@ Your goal is to execute the pending work for a given specification until the agr
 
 Follow this process precisely. Steps 2–5 form the per-task loop: repeat them for each task in scope, in document order, until the scope is exhausted. Step 6 runs once after the loop.
 
-### Step 1: Identify the Target Specification and Load Static Context
+### Step 1: Identify the Target Specification and Note Document Paths
 
 1.  Analyze `<user_prompt>`. If it names a specific task, set scope to that single task in the spec it belongs to. If it names a spec (without a specific task), set the target spec from the prompt and set scope to "every incomplete (`[ ]`) task in that spec".
 2.  Otherwise (no prompt): scan `context/spec/` in order, find the first directory whose `tasks.md` has an incomplete item (`[ ]`), select it as the target spec, and set scope to "every incomplete task in that spec".
 3.  If no target can be determined (ambiguous prompt, or all tasks are done), tell the user and stop.
 4.  Check the top of the target spec's `tasks.md` for the `<!-- not-user-reviewed -->` marker. `/awos:tasks` writes it when it saves a draft plan and removes it only after the user has reviewed the plan — if it is still present, this plan was never reviewed. Tell the user the plan is an unreviewed draft, ask them to re-run `/awos:tasks` to finish the review, and stop.
-5.  Load the static spec context once, in parallel:
-    - `[target-spec-directory]/functional-spec.md`
-    - `[target-spec-directory]/technical-considerations.md`
-
-    These files don't change during the run; Step 3 embeds their content into the delegation prompt for every task.
+5.  Note the paths of the three spec documents in the target directory — `functional-spec.md`, `technical-considerations.md`, and `tasks.md`. You hand these paths to each subagent so it reads what it needs itself (Step 3); their bodies never have to occupy your context. You read `tasks.md` because you orchestrate from it — the task lines, their markers, and their checkboxes are yours to work with.
 
 ### Step 2: Read `tasks.md` and Pick the Next Task
 
@@ -62,9 +58,9 @@ Follow this process precisely. Steps 2–5 form the per-task loop: repeat them f
 You do not write or edit code, configuration, or database schemas yourself. Your role is to delegate.
 
 1.  Construct a delegation prompt that includes:
-    - The full context from the three files loaded in Steps 1–2 (`functional-spec.md`, `technical-considerations.md`, `tasks.md`).
-    - The specific task description.
-    - Clear instructions on what code to write or files to modify.
+    - The paths to the three spec documents in the target directory (`functional-spec.md`, `technical-considerations.md`, `tasks.md`), with an instruction to read them directly for full context. Do not paste the documents' contents into the delegation prompt. The subagent is the one that needs those bodies, and it has its own context window to read them into — pulling them through yours costs context on every iteration of the loop and buys nothing.
+    - The task description, copied verbatim from the selected task line in `tasks.md`. Do not re-author, summarize, or copy content from `functional-spec.md` or `technical-considerations.md` into the delegation prompt — the subagent reads those itself from the paths above. A paraphrase is a second, drifting copy of text the subagent is about to read in full, and the documents stay the single source of truth only if nothing restates them.
+    - Clear instructions on what code to write or files to modify, framed as the task's own goal. Point the subagent at the relevant documents, and any sections the task line names, rather than reproducing them.
     - A `<scope_discipline>` block: "Only make changes the task requires. Don't add features, refactor unrelated code, or add validation for scenarios outside the task. If something is unclear, ask rather than guessing."
     - An `<investigate_before_answering>` block: "Don't speculate about code you haven't opened. Read relevant files before editing. Issue independent reads in parallel."
     - A `<use_available_skills>` block: "Apply any skills declared in your frontmatter `skills:` list, and any project, user, or plugin skills whose description matches this work. Skills carry project-specific patterns — they should shape your implementation."

--- a/tests/lint-prompts.test.js
+++ b/tests/lint-prompts.test.js
@@ -389,6 +389,49 @@ test('implement.md uses XML scope, investigate, skills, and completion-evidence 
   );
 });
 
+test('implement.md hands the subagent document paths instead of pasting contents', () => {
+  // Delegation hygiene, and an instance of the repo-wide rule that an
+  // orchestrator should not pull read-heavy material into its own context.
+  // The subagent is the one that needs the two spec bodies
+  // (functional-spec.md, technical-considerations.md) in full, and
+  // it has its own context window to read them into — so implement.md hands
+  // over the PATHS and lets the subagent read them, instead of the
+  // orchestrator loading every body and re-pasting it into the delegation
+  // prompt once per task. These two phrasings are the load-bearing wording;
+  // anchoring them stops a future edit from quietly reintroducing the
+  // paste-the-whole-triad-every-iteration shape.
+  const body = readUtf8(path.join(commandsDir, 'implement.md'));
+  assert.ok(
+    body.includes('read them directly'),
+    'implement.md must instruct the subagent to read the spec documents directly from their paths, rather than receiving their bodies inside the delegation prompt'
+  );
+  assert.ok(
+    body.includes('Do not paste the documents'),
+    "implement.md must forbid pasting the spec documents' contents into the delegation prompt — the orchestrator has no use for those bodies in its own context"
+  );
+});
+
+test('implement.md keeps the task description verbatim and unparaphrased', () => {
+  // The companion half of the paths-not-contents rule. Handing over paths
+  // achieves nothing if the orchestrator instead reads a document and
+  // re-authors its content into the delegation prompt: the same bulk comes
+  // back, now as a paraphrase that can drift from the file the subagent is
+  // about to read. So the prompt must (a) require the task description to be
+  // copied verbatim from the selected tasks.md line, keeping tasks.md the
+  // single source of truth for what the task says, and (b) forbid
+  // re-authoring/summarizing/copying functional-spec.md or
+  // technical-considerations.md content into the delegation prompt.
+  const body = readUtf8(path.join(commandsDir, 'implement.md'));
+  assert.ok(
+    /verbatim from the selected task line in `tasks\.md`/.test(body),
+    'implement.md must require the task description to be copied verbatim from the selected task line in tasks.md, so the delegated task cannot drift from the plan on disk'
+  );
+  assert.ok(
+    body.includes('Do not re-author, summarize, or copy'),
+    'implement.md must forbid the orchestrator re-authoring, summarizing, or copying functional-spec.md / technical-considerations.md content into the delegation prompt — a paraphrase reintroduces the bulk it just avoided and can drift from the document'
+  );
+});
+
 test('every core command declares an INTERACTION section', () => {
   // The "use AskUserQuestion for multiple-choice" rule lives in core
   // commands/*.md (not the wrappers), because AWOS targets Claude Code


### PR DESCRIPTION
 ## What

  - The orchestrator hands the coding subagent the paths to `functional-spec.md`, `technical-considerations.md`, and `tasks.md` and has it read them itself, instead of pre-loading two of those bodies into its own context and
  re-pasting all three into every delegation prompt.
  - The task description is copied verbatim from the selected `tasks.md` line rather than re-authored or summarized, and content from the other two documents is not restated in the prompt.
  - Layer-1 lint pins both rules: hand over the paths with a read-directly instruction and never paste document bodies, and keep the task description verbatim.
  - Adds Anthropic's "Mitigate jailbreaks and prompt injections" page — <https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/mitigate-jailbreaks> — to `CLAUDE.md`'s prompt-editing link list, as a standing
  reference for future edits to prompts that consume generated `context/` documents. It is not a rationale for this refactor, which makes no security claim.

  ## Why

  `/awos:implement` is an orchestrator: it picks the next task from `tasks.md`, delegates it, spot-checks what the subagent reports, and ticks the checkbox. It never needs the bodies of `functional-spec.md` and
  `technical-considerations.md` — the coding subagent does, and it has its own context window to read them into. Pulling them through the orchestrator's context kept both bodies resident in its window for the whole run and
  re-sent them with every delegation, and bought nothing the subagent couldn't get by reading the files itself. This is CLAUDE.md's existing rule for read-heavy work applied to the delegation prompt: don't have an orchestrator
  command read the whole codebase in its own context.

  Claude Code's subagent model makes that concrete: "Each subagent starts with a fresh, isolated context window. It doesn't see your conversation history, the skills you've already invoked, or the files Claude has already read"
  (<https://code.claude.com/docs/en/sub-agents>) — so an orchestrator-side read of the spec bodies is context spent on something the subagent never inherits. Anthropic's context-engineering guidance describes the shape adopted
  here: agents "maintain lightweight identifiers (file paths, …) and use these references to dynamically load data into context at runtime using tools"
  (<https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents>).

  Copying the task line verbatim is the same principle for the one excerpt that does get inlined. A paraphrase is a second, drifting copy of text the subagent is about to read in full, and the documents stay the single source of
  truth only if nothing restates them. That half is a DRY argument internal to AWOS's document-centric contract, not an Anthropic-sourced one.

  ## Tests

  Two Layer-1 lint tests anchor the new wording in `commands/implement.md`: the instruction to hand over the document paths and have them read directly, with document bodies never pasted, and the requirement that the task
  description be copied verbatim from the selected task line.
