### PR TITLE
fix(implement): gate on not-user-reviewed marker and verify subagent claims

### DIFF
--- a/commands/implement.md
+++ b/commands/implement.md
@@ -41,7 +41,8 @@ Follow this process precisely. Steps 2–5 form the per-task loop: repeat them f
 1.  Analyze `<user_prompt>`. If it names a specific task, set scope to that single task in the spec it belongs to. If it names a spec (without a specific task), set the target spec from the prompt and set scope to "every incomplete (`[ ]`) task in that spec".
 2.  Otherwise (no prompt): scan `context/spec/` in order, find the first directory whose `tasks.md` has an incomplete item (`[ ]`), select it as the target spec, and set scope to "every incomplete task in that spec".
 3.  If no target can be determined (ambiguous prompt, or all tasks are done), tell the user and stop.
-4.  Load the static spec context once, in parallel:
+4.  Check the top of the target spec's `tasks.md` for the `<!-- not-user-reviewed -->` marker. `/awos:tasks` writes it when it saves a draft plan and removes it only after the user has reviewed the plan — if it is still present, this plan was never reviewed. Ask via `AskUserQuestion` how to proceed: "Stop and review the plan first" (recommended — re-run `/awos:tasks` to finish the review) or "Proceed with the unreviewed draft". On stop, end the run. On proceed, continue but leave the marker in place — proceeding accepts the risk for this run only; it is not a review.
+5.  Load the static spec context once, in parallel:
     - `[target-spec-directory]/functional-spec.md`
     - `[target-spec-directory]/technical-considerations.md`
 
@@ -78,7 +79,12 @@ You do not write or edit code, configuration, or database schemas yourself. Your
 
 ### Step 4: Await and Verify Completion
 
-- Wait for the subagent to complete its work and report a successful outcome. You should assume that a success signal from the subagent means the task was completed as instructed.
+Wait for the subagent to finish and read its report. A subagent's report is a claim, not a fact — do not mark the task done on the success signal alone:
+
+1.  Spot-check the claim: read one or two of the files the report says it created or modified and confirm the described change is actually there.
+2.  Confirm the verification commands from the task's definition of success (Step 3) were run — the report should state their outcome. If the report is vague about verification, or the spot-check contradicts it, treat the task as failed: do not mark it `[x]`, stop the loop, surface the mismatch between the report and what you found, and wait for user direction.
+
+Keep this proportionate — a spot-check, not a full re-review. And it never turns you into an implementer: if the spot-check finds a gap, that is a failure to surface, not something to fix yourself.
 
 ### Step 5: Update Progress and Loop
 

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -41,7 +41,7 @@ Follow this process precisely. Steps 2–5 form the per-task loop: repeat them f
 1.  Analyze `<user_prompt>`. If it names a specific task, set scope to that single task in the spec it belongs to. If it names a spec (without a specific task), set the target spec from the prompt and set scope to "every incomplete (`[ ]`) task in that spec".
 2.  Otherwise (no prompt): scan `context/spec/` in order, find the first directory whose `tasks.md` has an incomplete item (`[ ]`), select it as the target spec, and set scope to "every incomplete task in that spec".
 3.  If no target can be determined (ambiguous prompt, or all tasks are done), tell the user and stop.
-4.  Check the top of the target spec's `tasks.md` for the `<!-- not-user-reviewed -->` marker. `/awos:tasks` writes it when it saves a draft plan and removes it only after the user has reviewed the plan — if it is still present, this plan was never reviewed. Ask via `AskUserQuestion` how to proceed: "Stop and review the plan first" (recommended — re-run `/awos:tasks` to finish the review) or "Proceed with the unreviewed draft". On stop, end the run. On proceed, continue but leave the marker in place — proceeding accepts the risk for this run only; it is not a review.
+4.  Check the top of the target spec's `tasks.md` for the `<!-- not-user-reviewed -->` marker. `/awos:tasks` writes it when it saves a draft plan and removes it only after the user has reviewed the plan — if it is still present, this plan was never reviewed. Tell the user the plan is an unreviewed draft, ask them to re-run `/awos:tasks` to finish the review, and stop.
 5.  Load the static spec context once, in parallel:
     - `[target-spec-directory]/functional-spec.md`
     - `[target-spec-directory]/technical-considerations.md`

--- a/tests/lint-prompts.test.js
+++ b/tests/lint-prompts.test.js
@@ -672,6 +672,28 @@ test('commands/tasks.md marks an unreviewed tasks.md and clears it on review', (
   );
 });
 
+test('commands/implement.md gates on the not-user-reviewed marker and verifies subagent claims', () => {
+  // /awos:implement is the marker's consumer: a draft-grade tasks.md
+  // must not execute silently. The literal marker string is the join
+  // key with commands/tasks.md. The same command must also treat a
+  // subagent's success report as a claim to spot-check, not a fact —
+  // the two trust gates that keep an unreviewed or unverified plan
+  // from advancing on autopilot.
+  const body = readUtf8(path.join(commandsDir, 'implement.md'));
+  assert.ok(
+    body.includes('<!-- not-user-reviewed -->'),
+    'commands/implement.md must check the literal "<!-- not-user-reviewed -->" marker before executing a plan, so drafts /awos:tasks saved unreviewed are gated'
+  );
+  assert.ok(
+    /claim, not a fact/i.test(body),
+    "commands/implement.md Step 4 must frame a subagent's report as a claim to verify, not a fact to relay"
+  );
+  assert.ok(
+    !/assume that a success signal/i.test(body),
+    'commands/implement.md must not instruct the orchestrator to assume a subagent success signal means the task completed'
+  );
+});
+
 test('commands/verify.md acknowledges the skip-tests marker', () => {
   // The Slack thread feedback frames /awos:verify as look-and-feel +
   // spec-freshness rather than a test runner. The skip-tests marker


### PR DESCRIPTION
## What

Backlog source: [Effort-Profit matrix, row 62](https://docs.superhuman.com/d/_dCoNoiEfeSz#Effort-Profit-matrix_tujgsglY/r62&view=center).

Two trust gates added to `commands/implement.md`:

1. **Unreviewed-plan gate.** Step 1 now checks the top of the target spec's `tasks.md` for the `<!-- not-user-reviewed -->` marker that `/awos:tasks` writes when it saves a draft plan (and removes only after user review). If the marker is present, the command tells the user the plan is an unreviewed draft, points at re-running `/awos:tasks` to finish the review, and stops — reviewing a plan happens only in `/awos:tasks`.
2. **Subagent claim verification.** Step 4 previously said to assume a subagent success signal means the task completed. It now treats the report as a claim, not a fact — aligned with the flow templates' wording: spot-check one or two of the files the report names, confirm the definition-of-success verification commands were run, and on a mismatch take the failure path (no `[x]`, stop the loop, surface the discrepancy). The orchestrator still never edits code itself; a gap found in the spot-check is a failure to surface, not something to fix.

## Why

Without the gate, an unreviewed draft `tasks.md` executed immediately — task selection never consulted the marker, making the review step in `/awos:tasks` skippable by accident. And blind trust in subagent success signals let unverified (or hallucinated) completions advance the plan and flip checkboxes.

## Tests

Layer-1 lint test locks the contract: the literal marker string as the join key with `commands/tasks.md`, the claim-not-fact framing in Step 4, and the absence of the old assume-success instruction. `npm run test:lint`: 93/93 pass; prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to pause or proceed when an implementation plan is marked as unreviewed.
  * Strengthened completion checks by requiring verification of reported changes and successful validation commands.

* **Tests**
  * Added coverage ensuring draft-plan handling and completion verification guidance remain enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
