### PR TITLE
feat: /awos:quick — ad-hoc task shortcut outside the spec cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,9 @@ The canonical flow (each command is a markdown prompt under `commands/`):
 
 The first four are run once at project setup; the last five iterate per feature. Each command reads/writes a specific document under `context/` (e.g. `context/product/product-definition.md`, `context/spec/NNN-feature/tasks.md`). The numeric prefix on spec directories is allocated by `scripts/create-spec-directory.sh`.
 
-**Implementation delegation rule:** `/awos:implement` is an orchestrator only — it reads `tasks.md`, extracts the `**[Agent: name]**` marker from each task, and delegates to a subagent. The orchestrator is explicitly prohibited from editing code itself. Preserve this contract when editing `commands/implement.md`.
+**Quick-task shortcut:** `/awos:quick` sits alongside the canonical flow for contained, one-off work that doesn't justify a full spec. It plans a single task, delegates to a specialist subagent, and writes `PLAN.md`/`SUMMARY.md` under `context/quick/NNNNNNNN-slug/` — separate from `context/spec/` and never tracked in the roadmap. It shares `/awos:implement`'s orchestrator-only contract (delegates all code changes) and offers `list`/`status`/`resume` subcommands.
+
+**Implementation delegation rule:** `/awos:implement` is an orchestrator only — it reads `tasks.md`, extracts the `**[Agent: name]**` marker from each task, and delegates to a subagent. The orchestrator is explicitly prohibited from editing code itself. Preserve this contract when editing `commands/implement.md`. `/awos:quick` follows the same rule.
 
 ## Architecture: Installer Pipeline
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For contained, one-off work that needs a plan and a specialist but not a full sp
 | `/awos:quick` | Executes a small ad-hoc task end-to-end — plans, delegates, summarizes. | [Details](docs/commands/quick.md) |
 | `/awos:q`     | Shortcut — identical to `/awos:quick`.                                  | [Details](docs/commands/quick.md) |
 
-`/awos:quick` plans the task, delegates the coding to a specialist subagent (the same specialists `/awos:implement` uses), and records a `PLAN.md` and `SUMMARY.md` under `context/quick/` — separate from the roadmap. When AWOS context files exist (product definition, architecture, roadmap), the subagent reads them before starting — so even quick tasks stay aligned with the project's design. It asks how thorough to be (plan-only, discuss, research, or full) and asks before committing. Use `/awos:quick list`, `status <slug>`, and `resume <slug>` to manage accumulated tasks.
+`/awos:quick` plans the task, delegates the coding to a specialist subagent (the same specialists `/awos:implement` uses), and records a `PLAN.md` and `SUMMARY.md` under `context/quick/` — separate from the roadmap. When AWOS context files exist (product definition, architecture, roadmap), the subagent reads them before starting — so even quick tasks stay aligned with the project's design. It asks how thorough to be (Plan and execute, Discuss first, Research first, or Full) and asks before committing. Use `/awos:quick list`, `status <slug>`, and `resume <slug>` to manage accumulated tasks.
 
 ### Step 4: You're Awesome
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ For contained, one-off work that needs a plan and a specialist but not a full sp
 | Command       | What it does                                                            | Docs                              |
 | ------------- | ----------------------------------------------------------------------- | --------------------------------- |
 | `/awos:quick` | Executes a small ad-hoc task end-to-end — plans, delegates, summarizes. | [Details](docs/commands/quick.md) |
+| `/awos:q`     | Shortcut — identical to `/awos:quick`.                                  | [Details](docs/commands/quick.md) |
 
-`/awos:quick` plans the task, delegates the coding to a specialist subagent (the same specialists `/awos:implement` uses), and records a `PLAN.md` and `SUMMARY.md` under `context/quick/` — separate from the roadmap. It asks how thorough to be (plan-only, discuss, research, or full) and asks before committing. Use `/awos:quick list`, `status <slug>`, and `resume <slug>` to manage accumulated tasks.
+`/awos:quick` plans the task, delegates the coding to a specialist subagent (the same specialists `/awos:implement` uses), and records a `PLAN.md` and `SUMMARY.md` under `context/quick/` — separate from the roadmap. When AWOS context files exist (product definition, architecture, roadmap), the subagent reads them before starting — so even quick tasks stay aligned with the project's design. It asks how thorough to be (plan-only, discuss, research, or full) and asks before committing. Use `/awos:quick list`, `status <slug>`, and `resume <slug>` to manage accumulated tasks.
 
 ### Step 4: You're Awesome
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ Once your foundation is set, iterate through this cycle for each feature on your
 
 > **When to skip the cycle**: Not every change needs a spec. Hotfixes, simple bugfixes, and small edits don't require the full spec workflow — Claude Code's built-in plan mode handles those just fine.
 
+### Quick Tasks
+
+For contained, one-off work that needs a plan and a specialist but not a full spec — a focused bugfix, a small refactor, a config or dependency change — use the shorter path:
+
+| Command       | What it does                                                            | Docs                              |
+| ------------- | ----------------------------------------------------------------------- | --------------------------------- |
+| `/awos:quick` | Executes a small ad-hoc task end-to-end — plans, delegates, summarizes. | [Details](docs/commands/quick.md) |
+
+`/awos:quick` plans the task, delegates the coding to a specialist subagent (the same specialists `/awos:implement` uses), and records a `PLAN.md` and `SUMMARY.md` under `context/quick/` — separate from the roadmap. It asks how thorough to be (plan-only, discuss, research, or full) and asks before committing. Use `/awos:quick list`, `status <slug>`, and `resume <slug>` to manage accumulated tasks.
+
 ### Step 4: You're Awesome
 
 That's it! By following these steps, you can systematically turn your vision into a well-defined and fully implemented product.

--- a/claude/commands/q.md
+++ b/claude/commands/q.md
@@ -3,4 +3,4 @@ description: Shortcut for /awos:quick — executes a small ad-hoc task end-to-en
 argument-hint: '[list | status <slug> | resume <slug> | task description]'
 ---
 
-@.awos/commands/quick.md
+@.awos/commands/q.md

--- a/claude/commands/q.md
+++ b/claude/commands/q.md
@@ -1,0 +1,6 @@
+---
+description: Shortcut for /awos:quick — executes a small ad-hoc task end-to-end.
+argument-hint: '[list | status <slug> | resume <slug> | task description]'
+---
+
+@.awos/commands/quick.md

--- a/claude/commands/quick.md
+++ b/claude/commands/quick.md
@@ -1,0 +1,6 @@
+---
+description: Executes a small ad-hoc task end-to-end — plans, delegates, summarizes — without the full spec cycle.
+argument-hint: '[list | status <slug> | resume <slug> | task description]'
+---
+
+@.awos/commands/quick.md

--- a/commands/q.md
+++ b/commands/q.md
@@ -1,0 +1,21 @@
+---
+description: Shortcut for /awos:quick — executes a small ad-hoc task end-to-end.
+---
+
+# ROLE
+
+This is an alias for `/awos:quick`. All behavior, rules, and process steps are identical.
+
+---
+
+# INTERACTION
+
+- Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+
+---
+
+# PROCESS
+
+Follow the full process defined in `.awos/commands/quick.md` — this command is identical in every way.
+
+Read the file `.awos/commands/quick.md` and execute it exactly as written, passing through the user's prompt unchanged.

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -94,7 +94,16 @@ If depth is "Research first" or "Full":
 - The research prompt should ask: what is the best approach for this task in _this_ codebase, which existing files/patterns to follow, and what pitfalls to avoid.
 - Fold the findings into `PLAN.md`.
 
-### Step 5: Write the Plan
+### Step 5: Choose the Specialist Subagent
+
+Determine which subagent should do the coding, reusing the same specialists as `/awos:implement`:
+
+- Enumerate the available subagents by inspecting the `Agent` tool's description block in your own system prompt (introspection — no tool call needed). Both project-local agents (declared as files under `.claude/agents/*.md`) and plugin-provided agents (recognized by the `plugin-name:` prefix on `subagent_type`) are listed there.
+- Match the task to a subagent by technology and intent (e.g. FastAPI/Python → a Python specialist, React/UI → a frontend specialist, DB → a database specialist, infra/CI → an infrastructure specialist).
+- If no specialist clearly matches — plain config edits, documentation, shell scripts, and other generic one-off work — use `general-purpose`. Don't force a stack specialist onto a task outside its domain just because the verification happens to use its language.
+- You'll record the choice in `PLAN.md` in the next step as `**[Agent: agent-name]**`.
+
+### Step 6: Write the Plan
 
 Write `context/quick/[YYYYMMDD]-[slug]/PLAN.md` with:
 
@@ -102,18 +111,9 @@ Write `context/quick/[YYYYMMDD]-[slug]/PLAN.md` with:
 - **Approach** — how it will be done (incorporating any discussion/research findings).
 - **Steps** — the concrete edits/actions, in order.
 - **Definition of Done** — how success is verified (tests, lint, typecheck, curl, manual check).
-- **Agent** — the specialist chosen in Step 6, recorded as `**[Agent: agent-name]**`.
+- **Agent** — the specialist chosen in Step 5, recorded as `**[Agent: agent-name]**`.
 
 Keep it short — a quick task's plan is a checklist, not a document.
-
-### Step 6: Choose the Specialist Subagent
-
-Determine which subagent should do the coding, reusing the same specialists as `/awos:implement`:
-
-- Enumerate the available subagents by inspecting the `Agent` tool's description block in your own system prompt (introspection — no tool call needed). Both project-local agents (declared as files under `.claude/agents/*.md`) and plugin-provided agents (recognized by the `plugin-name:` prefix on `subagent_type`) are listed there.
-- Match the task to a subagent by technology and intent (e.g. FastAPI/Python → a Python specialist, React/UI → a frontend specialist, DB → a database specialist, infra/CI → an infrastructure specialist).
-- If no specialist matches, use `general-purpose`.
-- Record the choice in `PLAN.md` as `**[Agent: agent-name]**`.
 
 ### Step 7: Delegate Execution
 
@@ -158,7 +158,9 @@ Set `status: incomplete` if the task could not be fully finished, and explain wh
 
 ### Step 10: Offer to Commit
 
-Ask the user with `AskUserQuestion` (header `Commit`, single-select) whether to commit the changes:
+First check whether the project is a git repository (e.g. `git rev-parse --is-inside-work-tree`). If it is **not** a repo, skip the commit question entirely — tell the user the changes are on disk and uncommitted because the project isn't under version control, and go to Step 11. Do not run `git init` on the user's behalf.
+
+If it is a repo, ask the user with `AskUserQuestion` (header `Commit`, single-select) whether to commit the changes:
 
 - **Commit now** — stage the changed files and create a single atomic commit with a concise message describing the task. If on the default branch, branch first per repo conventions.
 - **Don't commit** — leave the changes for the user to review.
@@ -167,7 +169,7 @@ Never commit without an explicit "Commit now" choice.
 
 ### Step 11: Report
 
-Report in a few lines: the task slug, what was done, files changed, verification result, and whether it was committed. Point the user to `context/quick/[YYYYMMDD]-[slug]/` for the plan and summary.
+Report in a few lines: the task slug, what was done, files changed, verification result, and whether it was committed (or that the project isn't a git repo, so nothing was committed). Point the user to `context/quick/[YYYYMMDD]-[slug]/` for the plan and summary.
 
 ---
 

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -1,0 +1,206 @@
+---
+description: Executes a small ad-hoc task end-to-end — plans, delegates, summarizes — without the full spec cycle.
+---
+
+# ROLE
+
+You are a Quick Task Coordinator. Your job is to take a single, small, ad-hoc task and drive it to completion through a short path: understand it, optionally clarify or research it, plan it briefly, delegate the coding to a specialist subagent, summarize the result, and offer to commit. You do **not** write code yourself — you plan and delegate, exactly like `/awos:implement`, but for one-off work that does not justify a full `spec → tech → tasks → implement → verify` cycle.
+
+Quick tasks are the same delegation system on a shorter path. They live in `context/quick/` — separate from planned specs in `context/spec/` — and are never tracked in the roadmap.
+
+---
+
+# TASK
+
+Execute one ad-hoc task described by the user (or manage previously created quick tasks via the `list`, `status`, and `resume` subcommands). For a run, you create a single `PLAN.md`, delegate the work to the best-matched specialist subagent, write a `SUMMARY.md` capturing the outcome, and ask the user whether to commit.
+
+Unlike the full cycle, quick mode skips research, discussion, and verification **by default**. Instead of flags, you **ask the user up front** how thorough they want the run to be.
+
+---
+
+# WHEN TO USE
+
+- **Use `/awos:quick`** for a self-contained task that needs a plan and a specialist but not a full spec: a focused bugfix, a small refactor, a config or dependency change, a one-off script, a contained enhancement.
+- **Use the full cycle** (`/awos:spec` → `/awos:tech` → `/awos:tasks` → `/awos:implement` → `/awos:verify`) for a roadmap feature — anything with multiple slices, cross-cutting acceptance criteria, or stakeholder-facing behavior worth specifying.
+- **Skip AWOS entirely** for a trivial edit you can make in one step — Claude Code's built-in plan mode handles those.
+
+---
+
+# INPUTS & OUTPUTS
+
+- **User Prompt:** <user_prompt>$ARGUMENTS</user_prompt>
+- **Task Storage:** `context/quick/` (created on first use).
+- **Per-task directory:** `context/quick/[YYYYMMDD]-[slug]/` containing:
+  - `PLAN.md` — the task goal, approach, steps, and definition of done.
+  - `SUMMARY.md` — the outcome, files changed, and status (written after execution).
+- **Action:** A call to a specialist subagent (via the `Agent` tool) to perform the coding.
+
+---
+
+# INTERACTION
+
+- Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
+- An unanswered or skipped question is never a stop signal — in an unattended run, fall back to the documented default and continue, including writing the task's `PLAN.md` and `SUMMARY.md`. The default depth is "Plan and execute"; the default commit choice is "Don't commit".
+
+---
+
+# PROCESS
+
+## Step 0: Parse Arguments and Route
+
+Inspect `<user_prompt>` and route:
+
+- Starts with `list` → go to **LIST**.
+- Starts with `status ` → the remainder is a slug → go to **STATUS**.
+- Starts with `resume ` → the remainder is a slug → go to **RESUME**.
+- Anything else (free-form text) → treat the whole prompt as the task description → go to **RUN**.
+- Empty prompt → ask the user to describe the task, then go to **RUN**.
+
+**Slug rules (for status/resume and slug generation):** lowercase, only `[a-z0-9-]`, max 60 characters, no `..` or `/`. When generating a slug from a task description, kebab-case the key words (e.g. "Fix Docker rate limit" → `fix-docker-rate-limit`). When reading a slug from arguments, strip disallowed characters; if the result is empty or invalid, tell the user and stop.
+
+---
+
+## RUN (default)
+
+### Step 1: Restate the Task and Choose Depth
+
+1.  Restate the task in one or two sentences so the user can confirm you understood it: "Quick task: [restatement]."
+2.  Ask how thorough the run should be with `AskUserQuestion` (header `Depth`, single-select):
+    - **Plan and execute** (Recommended) — go straight to a brief plan, then delegate.
+    - **Discuss first** — clarify the approach and surface assumptions before planning.
+    - **Research first** — investigate approaches, libraries, and pitfalls before planning.
+    - **Full** — discuss, then research, then plan, execute, and validate afterward.
+3.  Record the chosen depth. It enables: Discussion (Step 3), Research (Step 4), and post-execution Validation (Step 8). "Plan and execute" enables none of them.
+
+### Step 2: Create the Task Directory
+
+1.  Generate a slug from the task description (per Slug rules).
+2.  Compute today's date: `date +%Y%m%d`.
+3.  Create the directory: `mkdir -p context/quick/[YYYYMMDD]-[slug]`.
+4.  If a directory with the same slug already exists, ask the user whether to resume it (go to **RESUME**) or append a short disambiguator to the slug.
+
+### Step 3: Discussion (only if chosen)
+
+If depth is "Discuss first" or "Full":
+
+- Ask focused clarifying questions about the approach, constraints, and edge cases — only what genuinely affects how the task is done. Keep it lightweight; this is not a functional spec.
+- Capture the resolved decisions; they feed directly into `PLAN.md`.
+
+### Step 4: Research (only if chosen)
+
+If depth is "Research first" or "Full":
+
+- Delegate a focused investigation to a read-only research subagent (an `Explore`-style agent for locating code and patterns; `general-purpose` for broader questions or external docs).
+- The research prompt should ask: what is the best approach for this task in _this_ codebase, which existing files/patterns to follow, and what pitfalls to avoid.
+- Fold the findings into `PLAN.md`.
+
+### Step 5: Write the Plan
+
+Write `context/quick/[YYYYMMDD]-[slug]/PLAN.md` with:
+
+- **Goal** — the one-line task description.
+- **Approach** — how it will be done (incorporating any discussion/research findings).
+- **Steps** — the concrete edits/actions, in order.
+- **Definition of Done** — how success is verified (tests, lint, typecheck, curl, manual check).
+- **Agent** — the specialist chosen in Step 6, recorded as `**[Agent: agent-name]**`.
+
+Keep it short — a quick task's plan is a checklist, not a document.
+
+### Step 6: Choose the Specialist Subagent
+
+Determine which subagent should do the coding, reusing the same specialists as `/awos:implement`:
+
+- Enumerate the available subagents by inspecting the `Agent` tool's description block in your own system prompt (introspection — no tool call needed). Both project-local agents (declared as files under `.claude/agents/*.md`) and plugin-provided agents (recognized by the `plugin-name:` prefix on `subagent_type`) are listed there.
+- Match the task to a subagent by technology and intent (e.g. FastAPI/Python → a Python specialist, React/UI → a frontend specialist, DB → a database specialist, infra/CI → an infrastructure specialist).
+- If no specialist matches, use `general-purpose`.
+- Record the choice in `PLAN.md` as `**[Agent: agent-name]**`.
+
+### Step 7: Delegate Execution
+
+You do not write or edit code yourself. Construct a delegation prompt that includes:
+
+- The full `PLAN.md` content (goal, approach, steps, definition of done).
+- Any discussion decisions and research findings.
+- A `<scope_discipline>` block: "Only make changes the task requires. Don't add features, refactor unrelated code, or add validation for scenarios outside the task. If something is unclear, ask rather than guessing."
+- An `<investigate_before_answering>` block: "Don't speculate about code you haven't opened. Read relevant files before editing. Issue independent reads in parallel."
+- A `<use_available_skills>` block: "Apply any skills declared in your frontmatter `skills:` list, and any project, user, or plugin skills whose description matches this work."
+- A `<completion_evidence>` block: "Before reporting done, run the verification commands from the Definition of Done and cite their fresh output. Do not claim success from belief — show the evidence."
+
+Delegate via the `Agent` tool: `Agent(subagent_type="<agent-name>", description="<3-5 word summary>", prompt="<delegation prompt>")`. If no specialist was matched, set `subagent_type="general-purpose"`.
+
+Wait for the subagent to report completion. If it reports failure, stop, surface what went wrong, and do not proceed to commit without user direction.
+
+### Step 8: Validation (only if chosen)
+
+If depth is "Full":
+
+- Confirm the Definition of Done is actually met — run or delegate the verification commands, or drive the UI/API — rather than trusting the subagent's success signal. If a criterion fails, report it and either loop back to Step 7 (max 2 iterations) or stop for user direction.
+
+### Step 9: Write the Summary
+
+Write `context/quick/[YYYYMMDD]-[slug]/SUMMARY.md` with frontmatter and body:
+
+```md
+---
+status: complete # complete | incomplete
+date: [YYYY-MM-DD]
+---
+
+# [Task title]
+
+**Outcome:** [what was accomplished]
+**Files changed:** [list of files]
+**Verification:** [what was run and the result]
+**Notes:** [anything the user should know, follow-ups, or why it's incomplete]
+```
+
+Set `status: incomplete` if the task could not be fully finished, and explain why in Notes.
+
+### Step 10: Offer to Commit
+
+Ask the user with `AskUserQuestion` (header `Commit`, single-select) whether to commit the changes:
+
+- **Commit now** — stage the changed files and create a single atomic commit with a concise message describing the task. If on the default branch, branch first per repo conventions.
+- **Don't commit** — leave the changes for the user to review.
+
+Never commit without an explicit "Commit now" choice.
+
+### Step 11: Report
+
+Report in a few lines: the task slug, what was done, files changed, verification result, and whether it was committed. Point the user to `context/quick/[YYYYMMDD]-[slug]/` for the plan and summary.
+
+---
+
+## LIST
+
+1.  List task directories: `ls -d context/quick/*/ 2>/dev/null`. If none, print `No quick tasks found.` and stop.
+2.  For each directory, derive:
+    - **slug** — the directory name with the `YYYYMMDD-` prefix stripped. Before displaying, sanitize: strip non-printable characters and path separators. Never interpolate a raw directory name into a shell command.
+    - **date** — from the `YYYYMMDD-` prefix in the directory name.
+    - **status:**
+      - `SUMMARY.md` exists with frontmatter `status: complete` → `complete ✓`
+      - `SUMMARY.md` exists otherwise → `incomplete`
+      - `SUMMARY.md` missing, directory created < 7 days ago → `in-progress`
+      - `SUMMARY.md` missing, directory created ≥ 7 days ago → `abandoned? (>7 days, no summary)`
+3.  Display a table (slug, date, status) and a one-line count summary. Stop — do not run any task.
+
+---
+
+## STATUS
+
+Given a sanitized slug:
+
+1.  Find the directory: `ls -d context/quick/*-[slug]/ 2>/dev/null | head -1`. If none, print `No quick task found with slug: [slug]` and stop.
+2.  Read `PLAN.md` and `SUMMARY.md` (if present). Display: plan file path, status (from `SUMMARY.md` frontmatter or "no summary yet"), the task goal (from `PLAN.md`), and the last meaningful line of `SUMMARY.md` (or "none").
+3.  Print `Resume with: /awos:quick resume [slug]`. No subagent spawn. Stop.
+
+---
+
+## RESUME
+
+Given a sanitized slug:
+
+1.  Find the directory: `ls -d context/quick/*-[slug]/ 2>/dev/null | head -1`. If none, print `No quick task found with slug: [slug]` and stop.
+2.  Read `PLAN.md` (goal, approach, steps, agent) and `SUMMARY.md` (if present, for what's done).
+3.  Announce what you're resuming and the current status.
+4.  Continue from where the task left off: re-enter the RUN flow at Step 7 (Delegate Execution) using the existing `PLAN.md`, passing the subagent the plan plus a note of what remains. Then finish with Steps 8–11.

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -103,12 +103,30 @@ Determine which subagent should do the coding, reusing the same specialists as `
 - If no specialist clearly matches — plain config edits, documentation, shell scripts, and other generic one-off work — use `general-purpose`. Don't force a stack specialist onto a task outside its domain just because the verification happens to use its language.
 - You'll record the choice in `PLAN.md` in the next step as `**[Agent: agent-name]**`.
 
+### Step 5.5: DRY Validation
+
+Before writing the plan, check whether the task creates something that **parallels an existing structure** — a new environment, a second instance, a variant of existing code, a config for another target. If it does:
+
+1. **Default to reuse.** Extract shared logic into a module, template, base class, shared function, or parameterized config. The new instance should be a thin wrapper that passes different values — not a copy.
+2. **Parameterize the differences.** Use variables, tfvars files, env-specific overrides, CLI flags, factory arguments — whatever the stack's idiomatic mechanism is.
+3. **Only duplicate if reuse is genuinely impractical** (e.g. the "original" is a one-off script with no stable interface, or the overlap is < 30%). If you do duplicate, record **why** in the plan.
+
+**Red flag:** if a plan step says "copy X and change values" — stop and redesign. The correct step is "extract X into a reusable unit, then instantiate it twice with different parameters."
+
+This applies universally:
+- **Terraform/Infra:** modules + env var files, not copied directories.
+- **CI/CD:** shared templates / extends / anchors / reusable workflows, not duplicated jobs.
+- **Python/backend:** shared base classes / utilities / parameterized factories, not copied modules.
+- **React/frontend:** configurable components via props, not copied component files.
+- **Config:** overlays / env-specific overrides, not duplicated config files.
+
 ### Step 6: Write the Plan
 
 Write `context/quick/[YYYYMMDD]-[slug]/PLAN.md` with:
 
 - **Goal** — the one-line task description.
 - **Approach** — how it will be done (incorporating any discussion/research findings).
+- **DRY check** — if the task parallels something existing, explain the reuse strategy.
 - **Steps** — the concrete edits/actions, in order.
 - **Definition of Done** — how success is verified (tests, lint, typecheck, curl, manual check).
 - **Agent** — the specialist chosen in Step 5, recorded as `**[Agent: agent-name]**`.

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -41,6 +41,7 @@ Unlike the full cycle, quick mode skips research, discussion, and verification *
 
 - Use the `AskUserQuestion` tool for multiple-choice questions instead of plain text or numbered lists.
 - An unanswered or skipped question is never a stop signal — in an unattended run, fall back to the documented default and continue, including writing the task's `PLAN.md` and `SUMMARY.md`. The default depth is "Plan and execute"; the default commit choice is "Don't commit".
+- **Exception:** the task description itself has no meaningful default. If the prompt is empty and the user does not provide a description (skipped in unattended mode), stop with a message: "No task description provided — nothing to plan." This is the one legitimate stop condition.
 
 ---
 
@@ -76,8 +77,8 @@ Inspect `<user_prompt>` and route:
 
 1.  Generate a slug from the task description (per Slug rules).
 2.  Compute today's date: `date +%Y%m%d`.
-3.  Create the directory: `mkdir -p context/quick/[YYYYMMDD]-[slug]`.
-4.  If a directory with the same slug already exists (check via `ls -d context/quick/*-[slug]/ 2>/dev/null`), ask the user whether to resume it (go to **RESUME**) or append a numeric disambiguator (`-2`, `-3`, etc.) to the slug until unique.
+3.  Check for collisions: `ls -d context/quick/*-[slug]/ 2>/dev/null`. If a match exists, ask the user whether to resume it (go to **RESUME**) or append a numeric disambiguator (`-2`, `-3`, etc.) to the slug until unique.
+4.  Create the directory: `mkdir -p context/quick/[YYYYMMDD]-[slug]`.
 
 ### Step 3: Discussion (only if chosen)
 
@@ -160,7 +161,9 @@ You do not write or edit code yourself. Construct a delegation prompt that inclu
 
 Delegate via the `Agent` tool: `Agent(subagent_type="<agent-name>", description="<3-5 word summary>", prompt="<delegation prompt>")`. If no specialist was matched, set `subagent_type="general-purpose"`.
 
-Wait for the subagent to report completion. If it reports failure, stop, surface what went wrong, and do not proceed to commit without user direction.
+Wait for the subagent to report completion. On return, inspect the specialist's verification output: confirm the reported files exist and the cited evidence is present. If the evidence is missing or inconsistent, ask the subagent to re-run verification before accepting success.
+
+If the subagent reports failure, write `SUMMARY.md` with `status: incomplete` and the failure details in Notes, surface what went wrong to the user, and do not proceed to commit without user direction.
 
 ### Step 8: Validation (only if chosen)
 

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -77,7 +77,7 @@ Inspect `<user_prompt>` and route:
 1.  Generate a slug from the task description (per Slug rules).
 2.  Compute today's date: `date +%Y%m%d`.
 3.  Create the directory: `mkdir -p context/quick/[YYYYMMDD]-[slug]`.
-4.  If a directory with the same slug already exists, ask the user whether to resume it (go to **RESUME**) or append a short disambiguator to the slug.
+4.  If a directory with the same slug already exists (check via `ls -d context/quick/*-[slug]/ 2>/dev/null`), ask the user whether to resume it (go to **RESUME**) or append a numeric disambiguator (`-2`, `-3`, etc.) to the slug until unique.
 
 ### Step 3: Discussion (only if chosen)
 
@@ -99,7 +99,7 @@ If depth is "Research first" or "Full":
 Determine which subagent should do the coding, reusing the same specialists as `/awos:implement`:
 
 - Enumerate the available subagents by inspecting the `Agent` tool's description block in your own system prompt (introspection — no tool call needed). Both project-local agents (declared as files under `.claude/agents/*.md`) and plugin-provided agents (recognized by the `plugin-name:` prefix on `subagent_type`) are listed there.
-- Match the task to a subagent by technology and intent (e.g. FastAPI/Python → a Python specialist, React/UI → a frontend specialist, DB → a database specialist, infra/CI → an infrastructure specialist).
+- Match the task to a subagent by technology and intent (e.g. FastAPI/Python → a Python specialist, React/UI → a frontend specialist, DB → a database specialist, infra/CI → an infrastructure specialist). If multiple specialists match, prefer the narrower specialist over the generalist (e.g. a database agent over a backend agent for a SQL migration).
 - If no specialist clearly matches — plain config edits, documentation, shell scripts, and other generic one-off work — use `general-purpose`. Don't force a stack specialist onto a task outside its domain just because the verification happens to use its language.
 - You'll record the choice in `PLAN.md` in the next step as `**[Agent: agent-name]**`.
 
@@ -133,12 +133,24 @@ Write `context/quick/[YYYYMMDD]-[slug]/PLAN.md` with:
 
 Keep it short — a quick task's plan is a checklist, not a document.
 
+### Step 6.5: Gather Project Context
+
+Check which AWOS context files exist in the project:
+- `context/product/product-definition.md`
+- `context/architecture/architecture.md`
+- `context/product/roadmap.md`
+
+If any exist, include a `<project_context>` block in the delegation prompt (Step 7) listing the paths with the instruction: "Read these files before starting — they define the product, its architecture, and current roadmap. Align your changes with them."
+
+If none exist, skip this — the project may not have AWOS context yet, and the subagent can still work from the codebase alone.
+
 ### Step 7: Delegate Execution
 
 You do not write or edit code yourself. Construct a delegation prompt that includes:
 
 - The full `PLAN.md` content (goal, approach, steps, definition of done).
 - Any discussion decisions and research findings.
+- A `<project_context>` block (from Step 6.5): the list of existing context files with the instruction to read them before starting and align changes with the product definition and architecture.
 - A `<scope_discipline>` block: "Only make changes the task requires. Don't add features, refactor unrelated code, or add validation for scenarios outside the task. If something is unclear, ask rather than guessing."
 - An `<investigate_before_answering>` block: "Don't speculate about code you haven't opened. Read relevant files before editing. Issue independent reads in parallel."
 - A `<use_available_skills>` block: "Apply any skills declared in your frontmatter `skills:` list, and any project, user, or plugin skills whose description matches this work."
@@ -197,11 +209,11 @@ Report in a few lines: the task slug, what was done, files changed, verification
 2.  For each directory, derive:
     - **slug** — the directory name with the `YYYYMMDD-` prefix stripped. Before displaying, sanitize: strip non-printable characters and path separators. Never interpolate a raw directory name into a shell command.
     - **date** — from the `YYYYMMDD-` prefix in the directory name.
-    - **status:**
+    - **status** (determined by comparing the `YYYYMMDD` prefix to today's date):
       - `SUMMARY.md` exists with frontmatter `status: complete` → `complete ✓`
       - `SUMMARY.md` exists otherwise → `incomplete`
-      - `SUMMARY.md` missing, directory created < 7 days ago → `in-progress`
-      - `SUMMARY.md` missing, directory created ≥ 7 days ago → `abandoned? (>7 days, no summary)`
+      - `SUMMARY.md` missing, date prefix < 7 days ago → `in-progress`
+      - `SUMMARY.md` missing, date prefix ≥ 7 days ago → `abandoned? (>7 days, no summary)`
 3.  Display a table (slug, date, status) and a one-line count summary. Stop — do not run any task.
 
 ---
@@ -210,8 +222,8 @@ Report in a few lines: the task slug, what was done, files changed, verification
 
 Given a sanitized slug:
 
-1.  Find the directory: `ls -d context/quick/*-[slug]/ 2>/dev/null | head -1`. If none, print `No quick task found with slug: [slug]` and stop.
-2.  Read `PLAN.md` and `SUMMARY.md` (if present). Display: plan file path, status (from `SUMMARY.md` frontmatter or "no summary yet"), the task goal (from `PLAN.md`), and the last meaningful line of `SUMMARY.md` (or "none").
+1.  Find the directory: `ls -d context/quick/*-[slug]/ 2>/dev/null | tail -1`. If none, print `No quick task found with slug: [slug]` and stop. (`tail -1` picks the most recent match when the same slug exists on multiple dates, since the `YYYYMMDD-` prefix sorts chronologically.)
+2.  Read `PLAN.md` (if present) and `SUMMARY.md` (if present). Display: plan file path (or "no plan yet"), status (from `SUMMARY.md` frontmatter or "no summary yet"), the task goal (from `PLAN.md`'s Goal field), and the last non-empty, non-header line of `SUMMARY.md` (or "none").
 3.  Print `Resume with: /awos:quick resume [slug]`. No subagent spawn. Stop.
 
 ---
@@ -220,7 +232,10 @@ Given a sanitized slug:
 
 Given a sanitized slug:
 
-1.  Find the directory: `ls -d context/quick/*-[slug]/ 2>/dev/null | head -1`. If none, print `No quick task found with slug: [slug]` and stop.
-2.  Read `PLAN.md` (goal, approach, steps, agent) and `SUMMARY.md` (if present, for what's done).
-3.  Announce what you're resuming and the current status.
-4.  Continue from where the task left off: re-enter the RUN flow at Step 7 (Delegate Execution) using the existing `PLAN.md`, passing the subagent the plan plus a note of what remains. Then finish with Steps 8–11.
+1.  Find the directory: `ls -d context/quick/*-[slug]/ 2>/dev/null | tail -1`. If none, print `No quick task found with slug: [slug]` and stop. (`tail -1` picks the most recent match.)
+2.  Read `PLAN.md` (goal, approach, steps, agent) and `SUMMARY.md` (if present, for what's done). If `PLAN.md` is missing, inform the user that this task has no plan to resume and suggest starting fresh with `/awos:quick [task description]`. Stop.
+3.  If `SUMMARY.md` exists with `status: complete`, warn the user the task is already done and ask (via `AskUserQuestion`) whether to re-run it or stop.
+4.  Announce what you're resuming and the current status.
+5.  Run Step 6.5 (Gather Project Context) to check for AWOS context files — resumed tasks still need project alignment.
+6.  Extract the agent name from `PLAN.md`'s `**[Agent: agent-name]**` field. If the field is missing, fall back to Step 5 (Choose the Specialist Subagent) before delegating.
+7.  Continue from where the task left off: re-enter the RUN flow at Step 7 (Delegate Execution) using the existing `PLAN.md`, passing the subagent the plan plus a note of what remains. Then finish with Steps 8–11.

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -114,6 +114,7 @@ Before writing the plan, check whether the task creates something that **paralle
 **Red flag:** if a plan step says "copy X and change values" — stop and redesign. The correct step is "extract X into a reusable unit, then instantiate it twice with different parameters."
 
 This applies universally:
+
 - **Terraform/Infra:** modules + env var files, not copied directories.
 - **CI/CD:** shared templates / extends / anchors / reusable workflows, not duplicated jobs.
 - **Python/backend:** shared base classes / utilities / parameterized factories, not copied modules.
@@ -136,6 +137,7 @@ Keep it short — a quick task's plan is a checklist, not a document.
 ### Step 6.5: Gather Project Context
 
 Check which AWOS context files exist in the project:
+
 - `context/product/product-definition.md`
 - `context/architecture/architecture.md`
 - `context/product/roadmap.md`

--- a/docs/commands/quick.md
+++ b/docs/commands/quick.md
@@ -2,6 +2,8 @@
 
 > Executes a small ad-hoc task end-to-end — plans, delegates, summarizes — without the full spec cycle.
 
+**Shortcut:** `/awos:q` — identical behavior, shorter to type.
+
 ## What it does
 
 This command is a shorter path for one-off work that doesn't justify a full `spec → tech → tasks → implement → verify` cycle. Like `/awos:implement`, it acts as an orchestrator — it plans the task, delegates the coding to a specialist subagent, and tracks the outcome. It does **not** write code itself.
@@ -23,14 +25,18 @@ Nothing in `context/spec/` or the roadmap is touched.
 
 1.  **Restates the task** so you can confirm the intent.
 2.  **Asks how thorough to be** — instead of flags, the command asks up front: _Plan and execute_ (default), _Discuss first_, _Research first_, or _Full_ (discuss + research + validate).
-3.  **Optionally discusses** the approach and surfaces assumptions (if you chose Discuss or Full).
-4.  **Optionally researches** approaches and pitfalls via a read-only agent (if you chose Research or Full).
-5.  **Picks a specialist subagent** — reusing the same specialists as `/awos:implement`, matched by technology and intent (falls back to `general-purpose` for config, docs, scripts, and other generic work).
-6.  **Writes a short PLAN.md** — goal, approach, steps, definition of done, and the chosen specialist agent.
-7.  **Delegates execution** with full plan context and clear verification criteria.
-8.  **Optionally validates** the result against the definition of done (if you chose Full).
-9.  **Writes SUMMARY.md** — outcome, files changed, verification result, and status.
-10. **Offers to commit** — in a git repo, asks before committing and never commits without your explicit choice; in a non-repo project, skips the commit step and leaves the changes on disk.
+3.  **Creates a task directory** under `context/quick/[YYYYMMDD]-[slug]/`.
+4.  **Optionally discusses** the approach and surfaces assumptions (if you chose Discuss or Full).
+5.  **Optionally researches** approaches and pitfalls via a read-only agent (if you chose Research or Full).
+6.  **Picks a specialist subagent** — reusing the same specialists as `/awos:implement`, matched by technology and intent (falls back to `general-purpose` for config, docs, scripts, and other generic work). When multiple match, prefers the narrower specialist.
+7.  **Validates DRY** — checks whether the task parallels existing structure and defaults to reuse over duplication before planning.
+8.  **Writes a short PLAN.md** — goal, approach, DRY check, steps, definition of done, and the chosen specialist agent.
+9.  **Loads project context** — checks for `product-definition.md`, `architecture.md`, and `roadmap.md`. If they exist, the subagent is instructed to read them before starting and align changes with the product and architecture.
+10. **Delegates execution** with full plan context and clear verification criteria.
+11. **Optionally validates** the result against the definition of done (if you chose Full).
+12. **Writes SUMMARY.md** — outcome, files changed, verification result, and status.
+13. **Offers to commit** — in a git repo, asks before committing and never commits without your explicit choice; in a non-repo project, skips the commit step and leaves the changes on disk.
+14. **Reports** the slug, what was done, files changed, and points to the task directory.
 
 ## Subcommands
 
@@ -43,6 +49,8 @@ Nothing in `context/spec/` or the roadmap is touched.
 ## Key behaviors
 
 - **Strictly an orchestrator.** Like `/awos:implement`, it delegates all code changes to specialist subagents — it never writes code itself.
+- **Context-aware.** When AWOS context files exist (product definition, architecture, roadmap), the subagent reads them before starting — so even quick tasks stay aligned with the project's design decisions. This also applies to resumed tasks.
+- **DRY-first.** Before writing the plan, checks whether the task parallels existing structure and defaults to extracting shared logic rather than duplicating.
 - **Depth is a question, not a flag.** The command asks how thorough to be at the start, so quality gates are opt-in per run without memorizing flags.
 - **Asks before committing.** Changes are only committed when you explicitly choose to.
 - **Separate from the roadmap.** Quick tasks are tracked in `context/quick/`, never in `context/spec/` or the roadmap.
@@ -59,15 +67,18 @@ Nothing in `context/spec/` or the roadmap is touched.
 # Good — plan and execute a contained task:
 > /awos:quick Fix the Docker rate-limit failure by using the Artifactory proxy
 
+# Same thing using the shortcut:
+> /awos:q Fix the Docker rate-limit failure by using the Artifactory proxy
+
 # Good — investigate the approach before planning:
 > /awos:quick Add request retry with backoff to the API client
 # (then choose "Research first" when asked)
 
 # Good — audit accumulated quick tasks:
-> /awos:quick list
+> /awos:q list
 
 # Good — resume an in-progress task:
-> /awos:quick resume add-request-retry
+> /awos:q resume add-request-retry
 ```
 
 ## What happens next

--- a/docs/commands/quick.md
+++ b/docs/commands/quick.md
@@ -63,7 +63,7 @@ Nothing in `context/spec/` or the roadmap is touched.
 
 ## Example usage
 
-```bash
+```text
 # Good — plan and execute a contained task:
 > /awos:quick Fix the Docker rate-limit failure by using the Artifactory proxy
 

--- a/docs/commands/quick.md
+++ b/docs/commands/quick.md
@@ -1,0 +1,75 @@
+# /awos:quick
+
+> Executes a small ad-hoc task end-to-end — plans, delegates, summarizes — without the full spec cycle.
+
+## What it does
+
+This command is a shorter path for one-off work that doesn't justify a full `spec → tech → tasks → implement → verify` cycle. Like `/awos:implement`, it acts as an orchestrator — it plans the task, delegates the coding to a specialist subagent, and tracks the outcome. It does **not** write code itself.
+
+Quick tasks live in their own space, separate from planned features:
+
+- `context/quick/[YYYYMMDD]-[slug]/PLAN.md` — the task goal, approach, steps, and definition of done.
+- `context/quick/[YYYYMMDD]-[slug]/SUMMARY.md` — the outcome, files changed, and status (written after execution).
+
+Nothing in `context/spec/` or the roadmap is touched.
+
+## When to use it
+
+- **Use `/awos:quick`** for a self-contained task that still needs a plan and a specialist: a focused bugfix, a small refactor, a config or dependency change, a one-off script, a contained enhancement.
+- **Use the full cycle** for a roadmap feature — anything with multiple slices, cross-cutting acceptance criteria, or stakeholder-facing behavior worth specifying.
+- **Skip AWOS entirely** for a trivial edit you can make in one step — Claude Code's built-in plan mode handles those.
+
+## How it works
+
+1.  **Restates the task** so you can confirm the intent.
+2.  **Asks how thorough to be** — instead of flags, the command asks up front: _Plan and execute_ (default), _Discuss first_, _Research first_, or _Full_ (discuss + research + validate).
+3.  **Optionally discusses** the approach and surfaces assumptions (if you chose Discuss or Full).
+4.  **Optionally researches** approaches and pitfalls via a read-only agent (if you chose Research or Full).
+5.  **Writes a short PLAN.md** — goal, approach, steps, definition of done, and the chosen specialist agent.
+6.  **Picks a specialist subagent** — reusing the same specialists as `/awos:implement`, matched by technology and intent (falls back to `general-purpose`).
+7.  **Delegates execution** with full plan context and clear verification criteria.
+8.  **Optionally validates** the result against the definition of done (if you chose Full).
+9.  **Writes SUMMARY.md** — outcome, files changed, verification result, and status.
+10. **Offers to commit** — asks before committing; never commits without your explicit choice.
+
+## Subcommands
+
+| Subcommand      | What it does                                             |
+| --------------- | -------------------------------------------------------- |
+| `list`          | Lists all quick tasks with their date and status.        |
+| `status <slug>` | Shows a task's plan file, status, goal, and last action. |
+| `resume <slug>` | Resumes an in-progress quick task from its plan.         |
+
+## Key behaviors
+
+- **Strictly an orchestrator.** Like `/awos:implement`, it delegates all code changes to specialist subagents — it never writes code itself.
+- **Depth is a question, not a flag.** The command asks how thorough to be at the start, so quality gates are opt-in per run without memorizing flags.
+- **Asks before committing.** Changes are only committed when you explicitly choose to.
+- **Separate from the roadmap.** Quick tasks are tracked in `context/quick/`, never in `context/spec/` or the roadmap.
+
+## Common misconceptions
+
+- **"This replaces the spec cycle."** No. Use it for contained, one-off work. Roadmap features still belong in the full `spec → tech → tasks → implement → verify` cycle.
+- **"It writes the code."** No — it plans and delegates to a specialist subagent, exactly like `/awos:implement`.
+- **"It commits automatically."** No. It always asks first.
+
+## Example usage
+
+```bash
+# Good — plan and execute a contained task:
+> /awos:quick Fix the Docker rate-limit failure by using the Artifactory proxy
+
+# Good — investigate the approach before planning:
+> /awos:quick Add request retry with backoff to the API client
+# (then choose "Research first" when asked)
+
+# Good — audit accumulated quick tasks:
+> /awos:quick list
+
+# Good — resume an in-progress task:
+> /awos:quick resume add-request-retry
+```
+
+## What happens next
+
+The task's `PLAN.md` and `SUMMARY.md` remain under `context/quick/[YYYYMMDD]-[slug]/` as a lightweight record. Use `/awos:quick list` to audit accumulated tasks and `/awos:quick resume <slug>` to continue any that were left unfinished.

--- a/docs/commands/quick.md
+++ b/docs/commands/quick.md
@@ -25,12 +25,12 @@ Nothing in `context/spec/` or the roadmap is touched.
 2.  **Asks how thorough to be** — instead of flags, the command asks up front: _Plan and execute_ (default), _Discuss first_, _Research first_, or _Full_ (discuss + research + validate).
 3.  **Optionally discusses** the approach and surfaces assumptions (if you chose Discuss or Full).
 4.  **Optionally researches** approaches and pitfalls via a read-only agent (if you chose Research or Full).
-5.  **Writes a short PLAN.md** — goal, approach, steps, definition of done, and the chosen specialist agent.
-6.  **Picks a specialist subagent** — reusing the same specialists as `/awos:implement`, matched by technology and intent (falls back to `general-purpose`).
+5.  **Picks a specialist subagent** — reusing the same specialists as `/awos:implement`, matched by technology and intent (falls back to `general-purpose` for config, docs, scripts, and other generic work).
+6.  **Writes a short PLAN.md** — goal, approach, steps, definition of done, and the chosen specialist agent.
 7.  **Delegates execution** with full plan context and clear verification criteria.
 8.  **Optionally validates** the result against the definition of done (if you chose Full).
 9.  **Writes SUMMARY.md** — outcome, files changed, verification result, and status.
-10. **Offers to commit** — asks before committing; never commits without your explicit choice.
+10. **Offers to commit** — in a git repo, asks before committing and never commits without your explicit choice; in a non-repo project, skips the commit step and leaves the changes on disk.
 
 ## Subcommands
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -41,3 +41,9 @@ That is why **`awos`** is built on a vertical structure, moving from a high-leve
 5. **Task List**: The turn-by-turn directions for our walk.
 
 Each step provides the right information at the right level of detail. By following this process, you tell a complete and coherent story to the AI agents, ensuring they have the full context they need to build your vision into reality.
+
+## When the Full Map Is Too Much: Quick Tasks
+
+Not every journey needs a country map, a city map, and turn-by-turn directions. Some work is a short walk to a place you already know — a focused bugfix, a small refactor, a config change. Forcing that through the full vertical structure adds ceremony without adding context the agent actually needs.
+
+For those, `/awos:quick` offers a shorter path: it plans a single task, delegates the coding to the same specialist agents `/awos:implement` uses, and records a lightweight `PLAN.md` and `SUMMARY.md` under `context/quick/` — separate from the roadmap. It preserves the two principles that make the full structure work — a written plan before code, and a specialist doing the work — while dropping the layers a one-off task doesn't warrant. Reach for the full cycle when the work is a genuine feature with its own story to tell; reach for `/awos:quick` when it isn't.

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -44,6 +44,6 @@ Each step provides the right information at the right level of detail. By follow
 
 ## When the Full Map Is Too Much: Quick Tasks
 
-Not every journey needs a country map, a city map, and turn-by-turn directions. Some work is a short walk to a place you already know — a focused bugfix, a small refactor, a config change. Forcing that through the full vertical structure adds ceremony without adding context the agent actually needs.
+Not every journey needs a country map, a city map, and turn-by-turn directions. Some work is a short walk to a place you already know — a focused bug fix, a small refactor, a config change. Forcing that through the full vertical structure adds ceremony without adding context the agent actually needs.
 
 For those, `/awos:quick` offers a shorter path: it plans a single task, delegates the coding to the same specialist agents `/awos:implement` uses, and records a lightweight `PLAN.md` and `SUMMARY.md` under `context/quick/` — separate from the roadmap. It preserves the two principles that make the full structure work — a written plan before code, and a specialist doing the work — while dropping the layers a one-off task doesn't warrant. Reach for the full cycle when the work is a genuine feature with its own story to tell; reach for `/awos:quick` when it isn't.


### PR DESCRIPTION
## Why

AWOS gives AI agents full project context so they produce correct code — but the full workflow (`spec → tech → tasks → implement → verify`) takes five steps. That's the right investment for a roadmap feature, but overkill for everyday work: fixing a bug, tweaking a config, or doing a small refactor.

Without a lighter option, teams face an awkward choice: run the full ceremony for a 20-minute fix, or bypass AWOS entirely and lose the quality guarantees (a written plan, a matched specialist, alignment with architecture).

`/awos:quick` is the middle path. One command that still plans before coding, still picks the right specialist agent, and still reads the project's product definition and architecture — but skips the layers a small task doesn't need.

## Summary

- Adds `/awos:quick` — a single command for contained, one-off work that doesn't justify a full spec cycle.
- Plans the task, delegates coding to a specialist subagent (same pool as `/awos:implement`), and records `PLAN.md` + `SUMMARY.md` under `context/quick/`.
- Reads existing AWOS context files (`product-definition.md`, `architecture.md`, `roadmap.md`) before execution — so even quick tasks stay aligned with the project's design decisions.
- Includes `list`, `status <slug>`, and `resume <slug>` subcommands for task management.
- Separate from `context/spec/` and the roadmap — quick tasks never pollute the feature backlog.

## Usage examples

```bash
# Execute a contained task (default depth — plan and execute):
/awos:quick Fix the Docker rate-limit failure by using the Artifactory proxy

# Investigate before planning (choose "Research first" when asked):
/awos:q Add request retry with backoff to the API client

# Run with full depth — discuss, research, execute, validate:
/awos:q Migrate user sessions from Redis to PostgreSQL

# List all quick tasks with their status:
/awos:q list

# Check status of a specific task:
/awos:q status fix-docker-rate-limit

# Resume an incomplete task:
/awos:q resume add-request-retry
```

## What's included

| File | Purpose |
|------|---------|
| `commands/quick.md` | Full prompt — orchestrator logic |
| `claude/commands/quick.md` | Thin wrapper (user-editable customization layer) |
| `claude/commands/q.md` | `/awos:q` shortcut — points to the same prompt |
| `docs/commands/quick.md` | User-facing command documentation |
| `docs/rationale.md` | Philosophy section: when to use quick vs full cycle |
| `README.md` | Quick Tasks section added to the usage guide |
| `CLAUDE.md` | Internal docs updated: quick-task shortcut + delegation rule |

## Design decisions

- **Orchestrator-only contract** — like `/awos:implement`, it never writes code itself. All changes are delegated to specialist subagents.
- **Context-aware execution** — when AWOS context files exist, the subagent reads them before starting. If the project has no context yet, the step is skipped gracefully.
- **Depth is a question, not a flag** — asks the user up front how thorough to be (Plan and execute / Discuss first / Research first / Full) instead of requiring memorized CLI flags.
- **DRY validation** — before planning, checks whether the task parallels existing structure and defaults to reuse over duplication.
- **Explicit commit control** — never commits without the user's explicit choice; skips the question entirely in non-git projects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/awos:quick` for handling focused, one-off tasks through planning, specialist execution, optional validation, and commit confirmation.
  * Added `/awos:q` and `/quick` shortcuts.
  * Added `list`, `status`, and `resume` task-management commands.
  * Quick tasks now retain lightweight plans and summaries for later review or continuation.

* **Documentation**
  * Added usage guidance, workflow details, examples, and recommendations for choosing quick tasks versus full workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->