### PR TITLE
examples: golden-path todo-cli SDD walkthrough (AWO-3)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# AWOS Examples
+
+Reference projects that show the AWOS spec-driven development (SDD) cycle end to end, with **real artifacts at every stage** — the documents under each example's `context/` are what the `/awos:*` commands actually produce, not hand-written stand-ins.
+
+| Example                    | What it shows                                                                                                                                    | Stack                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| [`todo-cli/`](./todo-cli/) | The full golden path — product → roadmap → architecture → spec → tech → tasks → implement → verify — on a tiny, runnable, verified terminal app. | Node.js, zero-dep, CLI |
+
+## How to use these
+
+1. Read the example's `README.md` — it walks the flow stage by stage and links each artifact to the command that produced it.
+2. Skim `context/` to see how one stage feeds the next (the roadmap item becomes the spec, the spec's acceptance criteria become the tests, and so on).
+3. Follow the **Reproduce it yourself** section to run the same `/awos:*` chain in an empty directory and compare your output to the committed artifacts.
+
+Each example is self-contained and runnable. `todo-cli` needs only Node.js (`npm test` from its folder runs the verified suite).

--- a/examples/todo-cli/README.md
+++ b/examples/todo-cli/README.md
@@ -1,0 +1,113 @@
+# Golden-Path Example: Todo CLI
+
+This is a **complete, runnable walk-through of the entire AWOS spec-driven development (SDD) cycle** on one small-but-real project: a zero-dependency terminal todo list. Every document under [`context/`](./context) is a real artifact of the corresponding `/awos:*` command — not a hand-written stand-in — and the code under [`src/`](./src), [`bin/`](./bin), and [`test/`](./test) is what the flow actually produced and verified.
+
+Read it top to bottom to see how a vision becomes a verified feature, then reproduce it yourself.
+
+---
+
+## The app in 20 seconds
+
+```console
+$ todo add "write release notes"
+Added #1: write release notes
+$ todo add "fix flaky test"
+Added #2: fix flaky test
+$ todo list
+#1 [ ] write release notes
+#2 [ ] fix flaky test
+$ todo done 1
+Completed #1: write release notes
+$ todo remove 2
+Removed #2: fix flaky test
+$ todo list
+#1 [x] write release notes
+```
+
+Tasks persist automatically to `$TODO_FILE` (default `./.todo.json`). No dependencies, no config, no network — `node bin/todo.js <verb>`.
+
+Run it here:
+
+```bash
+cd examples/todo-cli
+node bin/todo.js add "try AWOS"
+node bin/todo.js list
+npm test   # 15 tests, all green
+```
+
+---
+
+## The AWOS flow, stage by stage
+
+Each stage below names the command that produced the artifact, what the command does, and the file it wrote. This is the exact order a newcomer runs them.
+
+### Foundation (run once)
+
+| #   | Command              | What it produced                                                  | Artifact                                                                           |
+| --- | -------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| 1   | `/awos:product`      | The non-technical product definition — what, why, for whom.       | [`context/product/product-definition.md`](./context/product/product-definition.md) |
+| 2   | `/awos:roadmap`      | Features grouped into sequential phases. Phase 1 is this feature. | [`context/product/roadmap.md`](./context/product/roadmap.md)                       |
+| 3   | `/awos:architecture` | The stack & persistence decisions (Node, zero-dep, JSON file).    | [`context/product/architecture.md`](./context/product/architecture.md)             |
+
+> A real project would also run `/awos:hire` here to install specialist agents. This example stays self-contained and uses the built-in `general-purpose` agent, so `/awos:hire` is intentionally skipped — see the note at the bottom of [`tasks.md`](./context/spec/001-manage-todos/tasks.md).
+
+### Feature cycle (once per roadmap feature)
+
+| #   | Command           | What it produced                                                                                                   | Artifact                                                                                                                   |
+| --- | ----------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| 4   | `/awos:spec`      | Functional spec — user-facing behavior + **testable acceptance criteria**.                                         | [`context/spec/001-manage-todos/functional-spec.md`](./context/spec/001-manage-todos/functional-spec.md)                   |
+| 5   | `/awos:tech`      | Technical spec — module breakdown, data model, CLI contract, risks.                                                | [`context/spec/001-manage-todos/technical-considerations.md`](./context/spec/001-manage-todos/technical-considerations.md) |
+| 6   | `/awos:tasks`     | Vertical **slices** of atomic tasks, each ending in a verify step.                                                 | [`context/spec/001-manage-todos/tasks.md`](./context/spec/001-manage-todos/tasks.md)                                       |
+| 7   | `/awos:implement` | The actual code — delegated per task, ticking `tasks.md` as it goes.                                               | [`src/`](./src), [`bin/`](./bin), [`test/`](./test)                                                                        |
+| 8   | `/awos:verify`    | Checked every acceptance criterion against the running app, marked them `[x]`, set the spec **Status: Completed**. | (updates the spec)                                                                                                         |
+
+The final states you can see in this folder are the _output_ of the whole run: every acceptance criterion in `functional-spec.md` is `[x]`, every task in `tasks.md` is `[x]`, and the spec is `Completed`.
+
+---
+
+## How the code maps to the tech spec
+
+The tech spec's core decision was a clean split between pure logic and I/O — that is exactly the shape of the code:
+
+- [`src/todo.js`](./src/todo.js) — **pure domain**: `addTask`, `completeTask`, `removeTask`, `nextId`, `formatList`. No filesystem access, so it is trivially unit-testable.
+- [`src/store.js`](./src/store.js) — **persistence edge**: `load`/`save` the JSON file, resolve `TODO_FILE`.
+- [`bin/todo.js`](./bin/todo.js) — **CLI edge**: parse argv → load → domain op → save → print; usage/errors to stderr with exit code 1.
+- [`test/todo.test.js`](./test/todo.test.js) — unit tests over the domain plus one acceptance test per criterion, driving `bin/todo.js` as a child process.
+
+One design subtlety worth calling out (the tech spec does too): `nextId` is `max(existing id) + 1`, **not** `length + 1`. Removing a middle task from `#1 #2 #3` leaves `#1 #3`; a length-based scheme would reissue `#3` and collide, while `max + 1` correctly yields `#4`. The test `next id stays unique after a middle removal` locks this in — revert `nextId` to length-based and it fails (that's the RED check the flow ran).
+
+---
+
+## Reproduce it yourself
+
+You do **not** need this folder's files to reproduce the flow — that's the point. Start empty and let the commands regenerate everything:
+
+```bash
+# 1. In an empty directory, install AWOS (sets up .awos/, .claude/commands/awos/, context/)
+mkdir my-todo && cd my-todo
+npx @provectusinc/awos
+
+# 2. Open the directory in Claude Code, then run the commands in order.
+#    Give /awos:product the same seed idea this example used:
+/awos:product a zero-config terminal todo list for developers who live in the shell
+/awos:roadmap
+/awos:architecture
+/awos:spec        # picks the first incomplete roadmap item: Manage Todos
+/awos:tech
+/awos:tasks
+/awos:implement
+/awos:verify
+```
+
+Compare each document the commands write under your `context/` to the committed artifacts here. They won't be byte-identical (the AI drafts prose fresh each run), but the **structure, the acceptance criteria, the slice breakdown, and the verified end state** will line up with what you see in this folder.
+
+> Tip: the commands are designed to run unattended — a skipped question falls back to a documented default and the deliverable is still written. So you can drive the whole chain even in a headless `claude -p` session.
+
+---
+
+## What this example demonstrates
+
+- A full, honest SDD loop: **product → roadmap → architecture → functional spec → technical spec → tasks → implementation → verification.**
+- Real artifacts at every stage, coherent with each other (the roadmap item, the spec, and the tests all describe the same feature).
+- A verification stage that **actually runs the software** and passes against the stated acceptance criteria (15/15 tests green, plus a demonstrated RED check).
+- The AWOS conventions in practice: vertical slices, `**[Agent: …]**` task markers, a Feature Testing & Regression slice, and `Status: Completed`.

--- a/examples/todo-cli/bin/todo.js
+++ b/examples/todo-cli/bin/todo.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// CLI edge: parse argv, dispatch on the verb, run the pure domain op, persist,
+// and print. All I/O and process concerns live here; src/todo.js stays pure.
+import { load, save, resolveFile } from '../src/store.js';
+import {
+  addTask,
+  completeTask,
+  removeTask,
+  formatList,
+  ValidationError,
+  NotFoundError,
+} from '../src/todo.js';
+
+const USAGE = `todo — a tiny terminal todo list
+
+Usage:
+  todo add "<text>"   Add a task
+  todo list           List all tasks
+  todo done <id>      Mark a task complete
+  todo remove <id>    Remove a task
+
+The list is saved to $TODO_FILE (default: ./.todo.json).`;
+
+function parseId(raw) {
+  // Non-integer / missing ids fall through to the standard "no task #<id>" path.
+  return Number.isInteger(Number(raw)) ? Number(raw) : NaN;
+}
+
+function main(argv) {
+  const [verb, ...rest] = argv;
+  const file = resolveFile();
+  const tasks = load(file);
+
+  switch (verb) {
+    case 'add': {
+      const { tasks: next, task } = addTask(tasks, rest.join(' '));
+      save(file, next);
+      console.log(`Added #${task.id}: ${task.text}`);
+      return;
+    }
+    case 'list': {
+      console.log(formatList(tasks));
+      return;
+    }
+    case 'done': {
+      const { tasks: next, task } = completeTask(tasks, parseId(rest[0]));
+      save(file, next);
+      console.log(`Completed #${task.id}: ${task.text}`);
+      return;
+    }
+    case 'remove': {
+      const { tasks: next, task } = removeTask(tasks, parseId(rest[0]));
+      save(file, next);
+      console.log(`Removed #${task.id}: ${task.text}`);
+      return;
+    }
+    default:
+      // No verb or an unknown verb: usage to stderr, non-zero exit.
+      throw new UsageError();
+  }
+}
+
+class UsageError extends Error {}
+
+try {
+  main(process.argv.slice(2));
+} catch (err) {
+  if (err instanceof UsageError) {
+    console.error(USAGE);
+  } else if (err instanceof ValidationError || err instanceof NotFoundError) {
+    console.error(`Error: ${err.message}`);
+  } else {
+    console.error(`Error: ${err.message}`);
+  }
+  process.exitCode = 1;
+}

--- a/examples/todo-cli/context/product/architecture.md
+++ b/examples/todo-cli/context/product/architecture.md
@@ -1,0 +1,46 @@
+# System Architecture Overview: Todo CLI
+
+_The guiding constraint from the product definition — "no app to open, no account, no network, zero config" — drives every choice below toward the smallest possible runtime with no external dependencies._
+
+---
+
+## 1. Application & Technology Stack
+
+- **Runtime:** Node.js (>= 18). _(Assumption — chosen because it is ubiquitous on developer machines and ships a built-in test runner; alternatives considered: a POSIX shell script (harder to test) or Python (heavier startup).)_
+- **Language:** Plain JavaScript (ES modules). No transpiler or build step.
+- **Distribution shape:** A single executable entry point (`bin/todo.js`) plus a small `src/` core, runnable directly with `node` or via an `npm`/`npx` bin link.
+- **Runtime dependencies:** None. The standard library (`node:fs`, `node:path`, `node:process`) covers everything.
+
+---
+
+## 2. Data & Persistence
+
+- **Primary store:** A single JSON file on the local filesystem holding an array of task records. _(Assumption — a flat JSON file matches the "zero-config, user-owns-the-data" goal; a real database would violate the no-setup constraint.)_
+- **Location:** `$TODO_FILE` when set, otherwise `.todo.json` in the current working directory.
+- **Record shape:** `{ id: number, text: string, done: boolean, createdAt: string (ISO 8601) }`.
+- **Id strategy:** Monotonic integer = (highest existing id) + 1, so ids stay stable and human-typeable even after removals.
+- **Concurrency:** Single-user, single-process, read-modify-write per command. No locking needed for the target use case.
+
+---
+
+## 3. Infrastructure & Deployment
+
+- **Packaging:** Published/consumed as a local Node package; `package.json` declares the `bin` mapping so `npm link` or `npx` exposes the `todo` command.
+- **Hosting environment:** None — the tool runs entirely on the user's machine.
+- **Configuration:** A single optional environment variable (`TODO_FILE`). No config files.
+
+---
+
+## 4. External Services & APIs
+
+- **Authentication:** None — the tool is single-user and local.
+- **Third-party services:** None. Offline by design.
+- **Network:** No network access is made at any point.
+
+---
+
+## 5. Observability & Quality
+
+- **User feedback:** Each command prints a one-line human-readable result to stdout; errors go to stderr with a non-zero exit code.
+- **Testing:** Node's built-in test runner (`node --test`) against the `src/` domain logic and the `bin/` CLI. No external test framework. _(Consistent with AWOS's own testing approach.)_
+- **Logging/Metrics:** Out of scope for a local single-user CLI.

--- a/examples/todo-cli/context/product/product-definition.md
+++ b/examples/todo-cli/context/product/product-definition.md
@@ -1,0 +1,63 @@
+# Product Definition: Todo CLI
+
+- **Version:** 1.0
+- **Status:** Proposed
+
+---
+
+## 1. The Big Picture (The "Why")
+
+### 1.1. Project Vision & Purpose
+
+To let a developer capture, track, and clear personal to-dos without ever leaving the terminal — no app to open, no account to create, no network round-trip. A task is one keystroke away and lives in a plain file the user owns.
+
+### 1.2. Target Audience
+
+Individual developers and terminal-native power users who already live in a shell and want a frictionless, offline task list for their own work — not teams, not project management.
+
+### 1.3. User Personas
+
+- **Persona 1: "Dana the Developer"**
+  - **Role:** Backend engineer who spends the day in a terminal and an editor.
+  - **Goal:** Jot down "fix the flaky test" mid-flow and check it off later, without breaking focus or reaching for a GUI.
+  - **Frustration:** Web/desktop todo apps demand context-switching, sign-ins, and sync; sticky notes and scratch files get lost.
+
+### 1.4. Success Metrics
+
+- A user can add a task and see it listed in under 2 seconds from a cold shell.
+- Every command is fully usable offline with zero configuration on first run.
+- 100% of the Phase 1 CLI behaviors are covered by automated acceptance tests that pass.
+
+---
+
+## 2. The Product Experience (The "What")
+
+### 2.1. Core Features
+
+- Add a task from the command line.
+- List all tasks with their completion status and an id.
+- Mark a task complete by id.
+- Remove a task by id.
+- Automatic, zero-config local persistence between commands.
+
+### 2.2. User Journey
+
+Dana opens a terminal, runs `todo add "write the release notes"`, and sees it confirmed with an id. Later she runs `todo list` to see everything outstanding, marks the finished item with `todo done 1`, and removes a stale one with `todo remove 2`. The list survives across sessions because it is saved to a local file automatically — she never configured anything.
+
+---
+
+## 3. Project Boundaries
+
+### 3.1. What's In-Scope for this Version
+
+- Adding, listing, completing, and removing tasks from the command line.
+- Automatic local persistence to a single JSON file on disk.
+- Clear, human-readable output and error messages with correct exit codes.
+
+### 3.2. What's Out-of-Scope (Non-Goals)
+
+- Due dates, priorities, tags, or sub-tasks _(candidates for a later phase)_.
+- Multi-user, sharing, or cloud sync.
+- Editing a task's text after creation.
+- A TUI, GUI, or web interface.
+- Configuration files or command-line flags beyond the four core verbs.

--- a/examples/todo-cli/context/product/roadmap.md
+++ b/examples/todo-cli/context/product/roadmap.md
@@ -1,0 +1,36 @@
+# Product Roadmap: Todo CLI
+
+_This roadmap outlines our strategic direction based on customer needs and business goals. It focuses on the "what" and "why," not the technical "how."_
+
+---
+
+### Phase 1
+
+_The highest priority features that form the core foundation of the product — a usable todo list from the command line._
+
+- [x] **Manage Todos**
+  - [x] **Add a Task:** Let the user record a new task from the command line and get immediate confirmation with an id.
+  - [x] **List Tasks:** Show every task with its completion status and id so the user can see what is outstanding.
+  - [x] **Complete a Task:** Let the user mark a task done by its id.
+  - [x] **Remove a Task:** Let the user delete a task by its id.
+  - [x] **Automatic Persistence:** Save tasks locally between commands with no setup, so the list survives across sessions.
+
+---
+
+### Phase 2
+
+_Once the core list works, we make individual tasks richer._
+
+- [ ] **Richer Tasks**
+  - [ ] **Due Dates:** Allow the user to attach an optional due date to a task and see overdue items highlighted in the list.
+  - [ ] **Priorities:** Allow the user to flag a task's priority and sort the list so the most important work surfaces first.
+
+---
+
+### Phase 3
+
+_Features planned for future consideration. Their priority and scope may be refined based on user feedback from earlier phases._
+
+- [ ] **Beyond a Single List**
+  - [ ] **Named Lists / Projects:** Let the user keep separate lists (e.g. "work" vs "home") and switch between them.
+  - [ ] **Export / Import:** Let the user move their tasks between machines by exporting and importing the list.

--- a/examples/todo-cli/context/spec/001-manage-todos/functional-spec.md
+++ b/examples/todo-cli/context/spec/001-manage-todos/functional-spec.md
@@ -1,0 +1,70 @@
+# Functional Specification: Manage Todos
+
+- **Roadmap Item:** Phase 1 — Manage Todos (add, list, complete, remove, automatic persistence)
+- **Status:** Completed
+- **Author:** Founding Engineer (via `/awos:spec`)
+
+---
+
+## 1. Overview and Rationale (The "Why")
+
+Developers who live in the terminal need to capture and clear personal to-dos without breaking flow. Today they reach for web apps that demand a context switch, or scratch files that get lost. This feature delivers the core loop — add, see, complete, remove — entirely from the command line, with the list saved automatically so it survives across sessions. Success means a user can go from a cold shell to a tracked task in a single command, offline and with zero configuration.
+
+---
+
+## 2. Functional Requirements (The "What")
+
+- **As a** terminal user, **I want to** add a task from the command line, **so that** I can capture work without leaving my shell.
+  - **Acceptance Criteria:**
+    - [x] Running `todo add "buy milk"` records the task and prints a confirmation that includes the new task's id and its text (e.g. `Added #1: buy milk`).
+    - [x] Running `todo add` with no text (or empty text) does **not** create a task; it prints an error such as `Error: task text required` and exits with a non-zero status.
+    - [x] Each added task receives an id that is unique among the current tasks (the next id is one greater than the largest current id), so it never collides with an existing task — even when an earlier task in the middle of the list was removed.
+
+- **As a** terminal user, **I want to** list my tasks, **so that** I can see what is outstanding.
+  - **Acceptance Criteria:**
+    - [x] Running `todo list` prints every task on its own line, each showing its id, a completion marker (`[ ]` for open, `[x]` for done), and its text.
+    - [x] When there are no tasks, `todo list` prints a friendly empty-state message (e.g. `No tasks yet.`) rather than nothing, and exits successfully.
+
+- **As a** terminal user, **I want to** mark a task complete by id, **so that** I can track what I have finished.
+  - **Acceptance Criteria:**
+    - [x] Running `todo done 1` marks task 1 complete and prints a confirmation (e.g. `Completed #1: buy milk`); a later `todo list` shows that task with the `[x]` marker.
+    - [x] Running `todo done` against an id that does not exist prints an error such as `Error: no task #<id>` and exits with a non-zero status, changing nothing.
+
+- **As a** terminal user, **I want to** remove a task by id, **so that** I can clear things that no longer matter.
+  - **Acceptance Criteria:**
+    - [x] Running `todo remove 1` deletes task 1 and prints a confirmation (e.g. `Removed #1: buy milk`); a later `todo list` no longer shows it.
+    - [x] Running `todo remove` against an id that does not exist prints an error such as `Error: no task #<id>` and exits with a non-zero status, changing nothing.
+
+- **As a** terminal user, **I want** my list to persist automatically, **so that** it is still there next time.
+  - **Acceptance Criteria:**
+    - [x] Tasks added in one command are present when a later, separate command runs, with no save step required from the user.
+    - [x] On the very first run, before any task exists, the tool behaves correctly (an empty list) without the user creating or configuring any file.
+
+- **General command behavior:**
+  - **Acceptance Criteria:**
+    - [x] Running `todo` with no arguments, or with an unrecognized command, prints a usage/help message listing the available commands and exits with a non-zero status.
+
+---
+
+## 3. Scope and Boundaries
+
+### In-Scope
+
+- The four verbs `add`, `list`, `done`, `remove`, plus help/usage output.
+- Automatic local persistence between commands.
+- Human-readable success and error messages with correct exit codes.
+
+### Out-of-Scope
+
+- Editing a task's text after creation.
+- Due dates, priorities, tags (Phase 2).
+- Multiple named lists, export/import, sync (Phase 3).
+- Any interactive prompt, TUI, or GUI.
+
+---
+
+## Change Log
+
+_No amendments yet._
+
+- [YYYY-MM-DD] — [source reference] — [what behavior changed and why]

--- a/examples/todo-cli/context/spec/001-manage-todos/tasks.md
+++ b/examples/todo-cli/context/spec/001-manage-todos/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Manage Todos
+
+_Vertical slices — after each slice the app is runnable and a new piece of user-visible value works. Task agent markers use `general-purpose` because this example installs no specialist agents (a real project would run `/awos:hire` first; see the Recommendations note). All tasks are `[x]`: this plan was executed by `/awos:implement` and confirmed by `/awos:verify`._
+
+- [x] **Slice 1: Add a task and see it persisted**
+  - [x] Scaffold the package: `package.json` (`type: module`, `bin` → `bin/todo.js`, `test` script) and empty `src/`, `bin/`, `test/` layout. **[Agent: general-purpose]**
+  - [x] Implement `src/store.js` — `load(file)` (empty array when the file is absent), `save(file, tasks)`, path resolution from `TODO_FILE` or `.todo.json`. **[Agent: general-purpose]**
+  - [x] Implement `addTask`/`nextId`/`formatTask` in `src/todo.js` and wire the `add` verb in `bin/todo.js` (load → add → save → print `Added #<id>: <text>`; empty text → `Error: task text required`, exit 1). **[Agent: general-purpose]**
+  - [x] Verify: run `todo add "buy milk"` twice against a temp `TODO_FILE`, confirm both are saved with ids #1 and #2 and the confirmation lines print; confirm empty text exits non-zero. Delete any scratch files produced. **[Agent: general-purpose]**
+
+- [x] **Slice 2: List tasks**
+  - [x] Implement `formatList` in `src/todo.js` and wire the `list` verb in `bin/todo.js` (one line per task `#<id> [ ]/[x] <text>`; `No tasks yet.` when empty). **[Agent: general-purpose]**
+  - [x] Verify: with a seeded `TODO_FILE`, run `todo list` and confirm each task renders with id, marker, and text; run against an empty file and confirm `No tasks yet.` with exit 0. Delete scratch files. **[Agent: general-purpose]**
+
+- [x] **Slice 3: Complete a task**
+  - [x] Implement `completeTask(tasks, id)` (throws `NotFoundError` on a missing id) and wire the `done` verb (`Completed #<id>: <text>`; missing id → `Error: no task #<id>`, exit 1). **[Agent: general-purpose]**
+  - [x] Verify: mark a seeded task done, confirm a subsequent `list` shows `[x]`; confirm `done 999` exits non-zero and changes nothing. Delete scratch files. **[Agent: general-purpose]**
+
+- [x] **Slice 4: Remove a task (ids not reused)**
+  - [x] Implement `removeTask(tasks, id)` (throws `NotFoundError` on a missing id); confirm `nextId` derives from max id so a new id never collides with a still-present task after a middle removal. Wire the `remove` verb (`Removed #<id>: <text>`; missing id → `Error: no task #<id>`, exit 1). **[Agent: general-purpose]**
+  - [x] Verify: with tasks `#1 #2 #3`, remove the middle one, confirm it disappears from `list`; add a new task and confirm it gets `#4` (max + 1) and collides with nothing; confirm `remove 999` exits non-zero. Delete scratch files. **[Agent: general-purpose]**
+
+- [x] **Slice 5: Usage / help and unknown-command handling**
+  - [x] In `bin/todo.js`, print a usage message listing the verbs when invoked with no args or an unknown verb, and exit 1. **[Agent: general-purpose]**
+  - [x] Verify: run `todo` and `todo bogus`, confirm usage text on stderr and non-zero exit. Delete scratch files. **[Agent: general-purpose]**
+
+- [x] **Slice 6: Feature Testing & Regression**
+
+  > Verifies the whole feature end-to-end against functional-spec.md, run after all implementation slices are complete.
+  - [x] Read functional-spec.md acceptance criteria in full. Generate acceptance-level tests that verify the entire feature as a whole — not individual slices. Cover unit (pure domain in `src/todo.js`) and integration/e2e (drive `bin/todo.js` as a child process against a temp `TODO_FILE`). Write tests with RED validation (must fail before implementation is confirmed done). Annotate each test with `@spec: 001-manage-todos` and `@regression`. **[Agent: general-purpose]**
+  - [x] Run all generated tests. All must pass. Fix any failures before proceeding. **[Agent: general-purpose]**
+
+---
+
+## Recommendations
+
+- **No specialist / QA agent installed:** This example is intentionally self-contained, so every task is assigned to the built-in `general-purpose` agent and the Feature Testing & Regression slice uses it too. In a real project you would run `/awos:hire` first to add a stack specialist (e.g. a Node/JS engineer) and a `testing-expert`, and `/awos:tasks` would assign those instead.

--- a/examples/todo-cli/context/spec/001-manage-todos/technical-considerations.md
+++ b/examples/todo-cli/context/spec/001-manage-todos/technical-considerations.md
@@ -1,0 +1,78 @@
+<!--
+This document describes HOW to build the feature at an architectural level.
+It is NOT a copy-paste implementation guide.
+-->
+
+# Technical Specification: Manage Todos
+
+- **Functional Specification:** ./functional-spec.md
+- **Status:** Completed
+- **Author(s):** Founding Engineer (via `/awos:tech`)
+
+---
+
+## 1. High-Level Technical Approach
+
+Implement the feature as a tiny, dependency-free Node.js package with a clean separation between three concerns: a **store** that reads/writes the JSON file, a **domain** module that holds the task operations as pure functions over an in-memory list, and a **CLI** entry point that parses argv, calls the domain, persists the result, and prints output. This keeps the domain logic trivially unit-testable without touching the filesystem, and confines all I/O to thin edges (the store and the CLI).
+
+Affected systems: none pre-exist — this is the first feature, so it establishes the project skeleton described in `architecture.md`.
+
+---
+
+## 2. Proposed Solution & Implementation Plan (The "How")
+
+### Component Breakdown
+
+| Path                | Responsibility                                                                                                                                                                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/todo.js`       | Pure domain functions over a task array: `addTask(tasks, text)`, `completeTask(tasks, id)`, `removeTask(tasks, id)`, `nextId(tasks)`, `formatTask(task)`, `formatList(tasks)`. No I/O. Throws typed errors (`ValidationError`, `NotFoundError`) on bad input. |
+| `src/store.js`      | Persistence edge: `load(file)` returns the task array (empty array if the file is absent), `save(file, tasks)` writes it. Resolves the target path from `TODO_FILE` env var or the `.todo.json` default.                                                      |
+| `bin/todo.js`       | CLI edge: parse `argv`, dispatch on the verb, load → mutate via domain → save, print result to stdout, print errors to stderr with `process.exitCode = 1`. Prints usage on unknown/empty command.                                                             |
+| `test/todo.test.js` | Acceptance + unit tests using `node --test`.                                                                                                                                                                                                                  |
+| `package.json`      | Declares `type: module`, the `bin` mapping (`todo` → `bin/todo.js`), and the `test` script.                                                                                                                                                                   |
+
+### Data Model
+
+A single JSON file (path from `TODO_FILE` or `.todo.json`) containing an array of records:
+
+| Field       | Type    | Notes                                                |
+| ----------- | ------- | ---------------------------------------------------- |
+| `id`        | number  | `max(existing ids) + 1`; unique among current tasks. |
+| `text`      | string  | Non-empty; trimmed.                                  |
+| `done`      | boolean | Defaults to `false`.                                 |
+| `createdAt` | string  | ISO 8601 timestamp.                                  |
+
+### CLI Contract
+
+| Invocation                  | Effect          | stdout                                                       | Exit |
+| --------------------------- | --------------- | ------------------------------------------------------------ | ---- |
+| `todo add "<text>"`         | append task     | `Added #<id>: <text>`                                        | 0    |
+| `todo add` / empty text     | none            | `Error: task text required` (stderr)                         | 1    |
+| `todo list`                 | —               | one line per task `#<id> [ ]/[x] <text>`, or `No tasks yet.` | 0    |
+| `todo done <id>`            | set `done=true` | `Completed #<id>: <text>`                                    | 0    |
+| `todo remove <id>`          | delete          | `Removed #<id>: <text>`                                      | 0    |
+| `todo done/remove <bad id>` | none            | `Error: no task #<id>` (stderr)                              | 1    |
+| `todo` / unknown verb       | none            | usage text (stderr)                                          | 1    |
+
+### Logic Notes
+
+- `nextId` derives from the **max** existing id, not the array length. This is what keeps ids unique after a middle `remove`: with tasks `#1 #2 #3`, removing `#2` leaves `#1 #3`; length-based numbering would hand the next task `#3` and collide, whereas `max + 1` correctly yields `#4`. (Ids of the highest task _may_ be reused once it is removed — the guarantee is uniqueness among current tasks, not lifetime-uniqueness.)
+- The CLI is the only place that resolves the store path and performs I/O; the domain stays pure so tests can exercise it in-memory.
+
+---
+
+## 3. Impact and Risk Analysis
+
+- **System Dependencies:** Node.js runtime only. No packages, no services, no network.
+- **Potential Risks & Mitigations:**
+  - _Corrupt or hand-edited JSON file_ → `store.load` wraps `JSON.parse` and fails with a clear `Error: could not read task file` rather than a raw stack trace.
+  - _Non-integer / missing id argument_ → treated as "no such task" and produces the standard `Error: no task #<id>` path, exit 1.
+  - _Working-directory-relative default file_ could surprise users running from different directories → documented in the example README; `TODO_FILE` gives an explicit override.
+
+---
+
+## 4. Testing Strategy
+
+- **Unit:** Domain functions in `src/todo.js` tested directly in-memory (add assigns ids, complete/remove by id, id uniqueness after a middle removal, validation errors).
+- **Integration / acceptance:** Drive `bin/todo.js` as a child process against a temp `TODO_FILE`, asserting stdout, exit codes, and cross-command persistence — one test per acceptance criterion in the functional spec.
+- **Runner:** `node --test` (built in, zero dependencies), matching the project architecture. RED validation: each acceptance test is written to fail before its behavior exists, then pass after.

--- a/examples/todo-cli/package.json
+++ b/examples/todo-cli/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "awos-example-todo-cli",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Golden-path AWOS example: a zero-dependency terminal todo list built end-to-end through the AWOS SDD cycle.",
+  "type": "module",
+  "bin": {
+    "todo": "bin/todo.js"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "license": "MIT"
+}

--- a/examples/todo-cli/src/store.js
+++ b/examples/todo-cli/src/store.js
@@ -1,0 +1,34 @@
+// Persistence edge: the only place that touches the filesystem. Resolves the
+// task file from the TODO_FILE env var, falling back to .todo.json in the
+// current working directory.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export function resolveFile(env = process.env) {
+  return resolve(env.TODO_FILE ?? '.todo.json');
+}
+
+// Returns the stored task array, or an empty array when the file does not yet
+// exist (first run needs no setup). A corrupt file surfaces a clear error
+// rather than a raw JSON stack trace.
+export function load(file) {
+  let raw;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+  try {
+    const data = JSON.parse(raw);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    throw new Error(`could not read task file: ${file}`);
+  }
+}
+
+export function save(file, tasks) {
+  writeFileSync(file, `${JSON.stringify(tasks, null, 2)}\n`, 'utf8');
+}

--- a/examples/todo-cli/src/todo.js
+++ b/examples/todo-cli/src/todo.js
@@ -1,0 +1,61 @@
+// Pure domain logic for the todo list. No I/O lives here — every function
+// takes the current task array and returns a result, so it is trivially
+// unit-testable. The CLI edge (bin/todo.js) handles persistence and printing.
+
+export class ValidationError extends Error {}
+export class NotFoundError extends Error {}
+
+// Next id is derived from the max existing id (not the array length) so that
+// ids are never reused after a task is removed.
+export function nextId(tasks) {
+  return tasks.reduce((max, t) => Math.max(max, t.id), 0) + 1;
+}
+
+export function addTask(tasks, text, now = new Date().toISOString()) {
+  const trimmed = (text ?? '').trim();
+  if (!trimmed) {
+    throw new ValidationError('task text required');
+  }
+  const task = {
+    id: nextId(tasks),
+    text: trimmed,
+    done: false,
+    createdAt: now,
+  };
+  return { tasks: [...tasks, task], task };
+}
+
+function findIndexById(tasks, id) {
+  const index = tasks.findIndex((t) => t.id === id);
+  if (index === -1) {
+    throw new NotFoundError(`no task #${id}`);
+  }
+  return index;
+}
+
+export function completeTask(tasks, id) {
+  const index = findIndexById(tasks, id);
+  const task = { ...tasks[index], done: true };
+  const next = tasks.slice();
+  next[index] = task;
+  return { tasks: next, task };
+}
+
+export function removeTask(tasks, id) {
+  const index = findIndexById(tasks, id);
+  const task = tasks[index];
+  const next = tasks.slice();
+  next.splice(index, 1);
+  return { tasks: next, task };
+}
+
+export function formatTask(task) {
+  return `#${task.id} [${task.done ? 'x' : ' '}] ${task.text}`;
+}
+
+export function formatList(tasks) {
+  if (tasks.length === 0) {
+    return 'No tasks yet.';
+  }
+  return tasks.map(formatTask).join('\n');
+}

--- a/examples/todo-cli/test/todo.test.js
+++ b/examples/todo-cli/test/todo.test.js
@@ -1,0 +1,198 @@
+// Feature Testing & Regression for spec 001-manage-todos.
+// @spec: 001-manage-todos
+// @regression
+//
+// Two layers:
+//   - unit tests over the pure domain in src/todo.js
+//   - acceptance tests that drive bin/todo.js as a child process against a
+//     temp TODO_FILE, one per acceptance criterion in functional-spec.md
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  addTask,
+  completeTask,
+  removeTask,
+  nextId,
+  formatList,
+  ValidationError,
+  NotFoundError,
+} from '../src/todo.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BIN = join(here, '..', 'bin', 'todo.js');
+
+// Run the CLI against an isolated temp file. Returns { stdout, status }.
+function runCli(args, todoFile) {
+  try {
+    const stdout = execFileSync('node', [BIN, ...args], {
+      env: { ...process.env, TODO_FILE: todoFile },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'], // capture stderr instead of inheriting it
+    });
+    return { stdout, status: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? '',
+      status: err.status,
+    };
+  }
+}
+
+function withTempFile(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'todo-cli-'));
+  const file = join(dir, 'tasks.json');
+  try {
+    return fn(file);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------- Unit: pure domain ----------
+
+test('addTask assigns sequential ids and trims text', () => {
+  let tasks = [];
+  ({ tasks } = addTask(tasks, '  buy milk  ', '2020-01-01T00:00:00.000Z'));
+  ({ tasks } = addTask(tasks, 'walk dog', '2020-01-01T00:00:00.000Z'));
+  assert.equal(tasks[0].id, 1);
+  assert.equal(tasks[0].text, 'buy milk');
+  assert.equal(tasks[1].id, 2);
+  assert.equal(tasks[0].done, false);
+});
+
+test('addTask rejects empty text', () => {
+  assert.throws(() => addTask([], '   '), ValidationError);
+});
+
+test('completeTask sets done and throws on missing id', () => {
+  let { tasks } = addTask([], 'buy milk');
+  ({ tasks } = completeTask(tasks, 1));
+  assert.equal(tasks[0].done, true);
+  assert.throws(() => completeTask(tasks, 999), NotFoundError);
+});
+
+test('removeTask deletes; next id stays unique after a middle removal', () => {
+  let { tasks } = addTask([], 'a');
+  ({ tasks } = addTask(tasks, 'b'));
+  ({ tasks } = addTask(tasks, 'c')); // ids 1, 2, 3
+  ({ tasks } = removeTask(tasks, 2)); // leaves 1, 3
+  assert.equal(tasks.length, 2);
+  // max+1 = 4 avoids colliding with the still-present #3 (length-based would give 3)
+  assert.equal(nextId(tasks), 4);
+  assert.throws(() => removeTask(tasks, 999), NotFoundError);
+});
+
+test('formatList renders markers and empty state', () => {
+  assert.equal(formatList([]), 'No tasks yet.');
+  const { tasks } = addTask([], 'buy milk');
+  assert.equal(formatList(tasks), '#1 [ ] buy milk');
+});
+
+// ---------- Acceptance: CLI end-to-end ----------
+
+test('add records a task and confirms with id and text', () => {
+  withTempFile((file) => {
+    const r = runCli(['add', 'buy milk'], file);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Added #1: buy milk/);
+  });
+});
+
+test('add with no text fails with a non-zero exit', () => {
+  withTempFile((file) => {
+    const r = runCli(['add'], file);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /task text required/);
+  });
+});
+
+test('list shows tasks with id, marker, and text; empty state when none', () => {
+  withTempFile((file) => {
+    assert.match(runCli(['list'], file).stdout, /No tasks yet\./);
+    runCli(['add', 'buy milk'], file);
+    const r = runCli(['list'], file);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /#1 \[ \] buy milk/);
+  });
+});
+
+test('done marks a task complete and list reflects it', () => {
+  withTempFile((file) => {
+    runCli(['add', 'buy milk'], file);
+    const r = runCli(['done', '1'], file);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Completed #1: buy milk/);
+    assert.match(runCli(['list'], file).stdout, /#1 \[x\] buy milk/);
+  });
+});
+
+test('done with a bad id fails and changes nothing', () => {
+  withTempFile((file) => {
+    runCli(['add', 'buy milk'], file);
+    const r = runCli(['done', '999'], file);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /no task #999/);
+    assert.match(runCli(['list'], file).stdout, /#1 \[ \] buy milk/);
+  });
+});
+
+test('remove deletes a task; next id stays unique after a middle removal', () => {
+  withTempFile((file) => {
+    runCli(['add', 'a'], file);
+    runCli(['add', 'b'], file);
+    runCli(['add', 'c'], file); // #1 #2 #3
+    const r = runCli(['remove', '2'], file);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Removed #2: b/);
+    // a new task takes #4 (max+1), not #3 which is still present
+    runCli(['add', 'd'], file);
+    const list = runCli(['list'], file).stdout;
+    assert.match(list, /#4 \[ \] d/);
+    assert.doesNotMatch(list, /#3 \[ \] d/);
+  });
+});
+
+test('remove with a bad id fails with a non-zero exit', () => {
+  withTempFile((file) => {
+    const r = runCli(['remove', '999'], file);
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /no task #999/);
+  });
+});
+
+test('persistence: tasks added in one command survive into the next', () => {
+  withTempFile((file) => {
+    runCli(['add', 'buy milk'], file);
+    runCli(['add', 'walk dog'], file);
+    const r = runCli(['list'], file);
+    assert.match(r.stdout, /#1 \[ \] buy milk/);
+    assert.match(r.stdout, /#2 \[ \] walk dog/);
+  });
+});
+
+test('first run needs no file to exist', () => {
+  withTempFile((file) => {
+    assert.equal(existsSync(file), false);
+    const r = runCli(['list'], file);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /No tasks yet\./);
+  });
+});
+
+test('no args or unknown command prints usage and exits non-zero', () => {
+  withTempFile((file) => {
+    const none = runCli([], file);
+    assert.equal(none.status, 1);
+    assert.match(none.stderr, /Usage:/);
+    const bogus = runCli(['bogus'], file);
+    assert.equal(bogus.status, 1);
+    assert.match(bogus.stderr, /Usage:/);
+  });
+});


### PR DESCRIPTION
## What

Adds `examples/todo-cli/` — a complete, runnable reference project that demonstrates the **full AWOS spec-driven development cycle end to end** on a small-but-real app: a zero-dependency terminal todo list. This closes the documented gap of thin examples.

Every document under `examples/todo-cli/context/` is a real artifact of the corresponding `/awos:*` stage, not a hand-written stand-in:

`/awos:product` → `/awos:roadmap` → `/awos:architecture` → `/awos:spec` → `/awos:tech` → `/awos:tasks` → `/awos:implement` → `/awos:verify`

`examples/todo-cli/{src,bin,test}` is the implementation the flow produced, and `examples/README.md` + `examples/todo-cli/README.md` walk a newcomer through reproducing each stage from an empty directory.

## Why

A newcomer following the AWOS README currently has no single worked example that carries one feature through every stage with coherent artifacts. This provides that golden path.

## Verification

- **Runs:** `node bin/todo.js add/list/done/remove` behaves per the spec's CLI contract (add, list, complete, remove, auto-persistence, usage/error exit codes).
- **Verification stage passes:** `node --test` → **15/15 green**, one acceptance test per functional-spec criterion (driving the CLI as a child process) plus domain unit tests.
- **RED-validated:** reverting `nextId` to length-based makes exactly the two id-uniqueness tests fail; restoring makes all 15 pass again — proving the tests catch a real regression.
- Conforms to the repo's Prettier config (`prettier examples --check` clean). Scoped under `examples/`, isolated from framework core and the installer.

## Reviewer notes

- The example intentionally installs **no specialist agents** (`/awos:hire` skipped) so it stays self-contained; every task is assigned to the built-in `general-purpose` agent, with a note in `tasks.md` explaining what a real project would do instead.
- One deliberate design decision is documented in the tech spec and README: task ids are `max(current id) + 1` (unique among current tasks), not lifetime-unique — this is what prevents collisions after a middle task is removed.

Tracking issue: **AWO-3** (blocked-by **AWO-2**, the dev-environment / contribution-workflow foundation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)