### PR TITLE
docs: philosophy, direction, and a rewritten rationale

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,9 @@ cd awos
 awos/
 ├── docs/                # AWOS documentation
 │   ├── commands/        # Individual command reference docs
-│   ├── rationale.md
+│   ├── philosophy.md    # What awos is and is not; the principles every change is measured against
+│   ├── direction.md     # The directions awos always moves in; a test for new ideas
+│   ├── rationale.md     # Why awos works, for first-time readers
 │   └── testing-strategies.md
 ├── scripts/             # AWOS scripts
 ├── commands/            # AWOS command prompts

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ That's it! By following these steps, you can systematically turn your vision int
 
 ## The `awos` Philosophy
 
-The **`awos`** framework is built on a simple but powerful idea: AI agents, like human developers, need clear context to do great work. Without a structured plan, even the most advanced LLM can act like a confused intern. **`awos`** provides a step-by-step workflow that transforms your vision into a detailed blueprint that AI agents can understand and execute flawlessly.
+**`awos`** is a method for turning intent into working software with agents, where the human decides and the agent builds. Its product is not documents but agreement — a confirmed, shared understanding between you and the agent about what is being built and why, reached before any code is written.
 
-[Read more about the philosophy behind **`awos`**](docs/rationale.md)
+[Why **`awos`** works](docs/rationale.md) · [The philosophy](docs/philosophy.md) · [Where it is heading](docs/direction.md)
 
 ## Command Reference
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ These commands establish your project's foundation. Run them once at the start, 
 
 Once your foundation is set, iterate through this cycle for each feature on your roadmap. These commands are designed to be run repeatedly — once per feature.
 
-> **Tip**: Don't hesitate to delete specs after implementation. Completed specs can become outdated and confuse the AI. Your code documentation is the source of truth.
-
 | Command           | What it does                                                                      | Docs                                  |
 | ----------------- | --------------------------------------------------------------------------------- | ------------------------------------- |
 | `/awos:spec`      | Creates the Functional Spec — what the feature does for the user.                 | [Details](docs/commands/spec.md)      |

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -11,7 +11,7 @@ The directions `awos` always moves in. None of them is ever finished, since each
 - **Advancing looks like:** a misunderstanding surfaces earlier than it did before; the time to a confident yes or no goes down; something a person had to hold in their head is now something they can read.
 - **Regressing looks like:** more content to review without more decisions to make; a check that happens after implementation instead of before; a confirmation that is a formality because nobody could evaluate it.
 
-Serves principles 1, 3, 5, and 6.
+Serves principles 1, 3, 6, and 7.
 
 ## Toward discovery
 
@@ -22,7 +22,7 @@ Intent is scattered across code, tickets, documentation, past decisions, and oth
 - **Advancing looks like:** a source of intent that `awos` reads on its own; a question the human no longer has to be asked; a gap that is surfaced as unknown instead of silently filled.
 - **Regressing looks like:** a longer interview; a file the human must maintain so that the agent can read it; an agent that resolves ambiguity by picking the plausible option.
 
-Serves principle 2; supports 3 and 6.
+Serves principle 2; supports 3 and 7.
 
 ## Toward memory
 
@@ -33,7 +33,7 @@ A project that remembers what it is makes every subsequent change easier to spec
 - **Advancing looks like:** knowledge produced by a change is retained by the flow itself; a later spec reads what an earlier one established; the product's current behavior is available to the agent, not only its history of intentions.
 - **Regressing looks like:** artifacts treated as disposable once implemented; upkeep of knowledge delegated to people; a document nothing in the flow keeps current.
 
-Serves principle 7; deepens 6.
+Serves principle 8; deepens 7.
 
 ## Toward fidelity
 
@@ -44,7 +44,7 @@ Agreement is only worth reaching if the build honors it. `awos` moves toward imp
 - **Advancing looks like:** fewer corrections between implementation and verification; a deviation from the agreement caught by the flow rather than by a person; an implementation that needs less supervision to stay on the agreed path.
 - **Regressing looks like:** an agent improvising beyond what was agreed; verification that checks only that the code works, not that it is what was agreed; a capability that improves code in general but not its fidelity to the agreement.
 
-Serves principles 1 and 4.
+Serves principles 1, 4, and 5.
 
 ## Toward a smaller surface
 
@@ -55,4 +55,4 @@ The method is a single path: intent → confirmed understanding → implementati
 - **Advancing looks like:** fewer commands doing the same work; an integration in place of an owned capability; a proven experiment folded into core and its predecessor removed.
 - **Regressing looks like:** a capability that sits outside the path, however useful; two ways to do the same step kept alive indefinitely; a feature that serves the host tool rather than the method.
 
-Serves principles 8 and 10.
+Serves principles 9 and 11.

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -1,0 +1,58 @@
+# Direction
+
+The directions `awos` always moves in. None of them is ever finished — each is something the framework can always be more of — and none carries a date or a priority; those belong to the roadmap. Each follows from the principles in [Philosophy](philosophy.md).
+
+## Toward agreement
+
+**Does this make the human's confirmation of the agent's understanding more reliable, or cheaper?**
+
+`awos` exists for the moment where a person sees what the agent understood and says "yes, that" or "no, not that." Everything that makes that moment more certain, or faster, or possible at all for a person with little time, is movement in this direction.
+
+- **Advancing looks like:** a misunderstanding surfaces earlier than it did before; the time to a confident yes or no goes down; something a person had to hold in their head is now something they can read.
+- **Regressing looks like:** more content to review without more decisions to make; a check that happens after implementation instead of before; a confirmation that is really a formality because nobody could evaluate it.
+
+Serves principles 1, 3, 5, and 6.
+
+## Toward discovery
+
+**Does this bring intent to the human from where it lives, instead of asking the human to produce it?**
+
+Intent is scattered — across code, tickets, documentation, past decisions, and other people. `awos` moves toward finding it there by default and asking the human only what nobody else can answer.
+
+- **Advancing looks like:** a source of intent that `awos` reads on its own; a question the human no longer has to be asked; a gap that is surfaced as unknown instead of silently filled.
+- **Regressing looks like:** a longer interview; a file the human must maintain so that the agent can read it; an agent that resolves ambiguity by picking the plausible option.
+
+Serves principle 2; supports 3 and 6.
+
+## Toward memory
+
+**Does the next piece of work start from more than this one did?**
+
+A project that remembers what it is makes every subsequent change easier to specify than the last. `awos` moves toward keeping that knowledge current as a side effect of the work, so that no piece of work begins from a blank page and "what does this leave unchanged?" is a question with an answer.
+
+- **Advancing looks like:** knowledge produced by a change is retained by the flow itself; a later spec reads what an earlier one established; the product's current behavior is available to the agent, not only its history of intentions.
+- **Regressing looks like:** artifacts treated as disposable once implemented; upkeep of knowledge delegated to people; a document nothing in the flow keeps current.
+
+Serves principle 7; deepens 6.
+
+## Toward fidelity
+
+**Does this make what gets built match the confirmed understanding more closely, or make a deviation visible sooner?**
+
+Agreement is only worth reaching if the build honors it. `awos` moves toward implementation that stays on the agreed path without supervision and verification that checks the result against the agreement rather than against the code's own idea of correctness.
+
+- **Advancing looks like:** fewer corrections between implementation and verification; a deviation from the agreement caught by the flow rather than by a person; an implementation that needs less supervision to stay on the agreed path.
+- **Regressing looks like:** an agent improvising beyond what was agreed; verification that checks only that the code works, not that it is what was agreed; a capability that improves code in general but not its fidelity to the agreement.
+
+Serves principles 1 and 4.
+
+## Toward a smaller surface
+
+**Does this make the method more visible, or the tool bigger?**
+
+The method is a single path: intent → confirmed understanding → implementation → verification. `awos` moves toward a surface small enough that a newcomer can see that path in it, integrating with everything around it rather than absorbing it.
+
+- **Advancing looks like:** fewer commands doing the same work; an integration in place of an owned capability; a proven experiment folded into core and its predecessor removed.
+- **Regressing looks like:** a capability that sits outside the path, however useful; two ways to do the same step kept alive indefinitely; a feature that serves the host tool rather than the method.
+
+Serves principles 8 and 9.

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -1,15 +1,15 @@
 # Direction
 
-The directions `awos` always moves in. None of them is ever finished — each is something the framework can always be more of — and none carries a date or a priority; those belong to the roadmap. Each follows from the principles in [Philosophy](philosophy.md).
+The directions `awos` always moves in. None of them is ever finished, since each is something the framework can always be more of, and none carries a date or a priority; those belong to the roadmap. Each follows from the principles in [Philosophy](philosophy.md).
 
 ## Toward agreement
 
 **Does this make the human's confirmation of the agent's understanding more reliable, or cheaper?**
 
-`awos` exists for the moment where a person sees what the agent understood and says "yes, that" or "no, not that." Everything that makes that moment more certain, or faster, or possible at all for a person with little time, is movement in this direction.
+`awos` exists for the moment where a person sees what the agent understood and says "yes, that" or "no, not that." Everything that makes that moment more certain, faster, or possible at all for a person with little time is movement in this direction.
 
 - **Advancing looks like:** a misunderstanding surfaces earlier than it did before; the time to a confident yes or no goes down; something a person had to hold in their head is now something they can read.
-- **Regressing looks like:** more content to review without more decisions to make; a check that happens after implementation instead of before; a confirmation that is really a formality because nobody could evaluate it.
+- **Regressing looks like:** more content to review without more decisions to make; a check that happens after implementation instead of before; a confirmation that is a formality because nobody could evaluate it.
 
 Serves principles 1, 3, 5, and 6.
 
@@ -17,7 +17,7 @@ Serves principles 1, 3, 5, and 6.
 
 **Does this bring intent to the human from where it lives, instead of asking the human to produce it?**
 
-Intent is scattered — across code, tickets, documentation, past decisions, and other people. `awos` moves toward finding it there by default and asking the human only what nobody else can answer.
+Intent is scattered across code, tickets, documentation, past decisions, and other people. `awos` moves toward finding it there by default and asking the human only what nobody else can answer.
 
 - **Advancing looks like:** a source of intent that `awos` reads on its own; a question the human no longer has to be asked; a gap that is surfaced as unknown instead of silently filled.
 - **Regressing looks like:** a longer interview; a file the human must maintain so that the agent can read it; an agent that resolves ambiguity by picking the plausible option.
@@ -28,7 +28,7 @@ Serves principle 2; supports 3 and 6.
 
 **Does the next piece of work start from more than this one did?**
 
-A project that remembers what it is makes every subsequent change easier to specify than the last. `awos` moves toward keeping that knowledge current as a side effect of the work, so that no piece of work begins from a blank page and "what does this leave unchanged?" is a question with an answer.
+A project that remembers what it is makes every subsequent change easier to specify than the last. `awos` moves toward keeping that knowledge current as a side effect of the work, so that no piece of work begins from a blank page and "what does this leave unchanged?" can be answered.
 
 - **Advancing looks like:** knowledge produced by a change is retained by the flow itself; a later spec reads what an earlier one established; the product's current behavior is available to the agent, not only its history of intentions.
 - **Regressing looks like:** artifacts treated as disposable once implemented; upkeep of knowledge delegated to people; a document nothing in the flow keeps current.
@@ -39,7 +39,7 @@ Serves principle 7; deepens 6.
 
 **Does this make what gets built match the confirmed understanding more closely, or make a deviation visible sooner?**
 
-Agreement is only worth reaching if the build honors it. `awos` moves toward implementation that stays on the agreed path without supervision and verification that checks the result against the agreement rather than against the code's own idea of correctness.
+Agreement is only worth reaching if the build honors it. `awos` moves toward implementation that stays on the agreed path without supervision and verification that checks the result against the agreement rather than against whether the code runs.
 
 - **Advancing looks like:** fewer corrections between implementation and verification; a deviation from the agreement caught by the flow rather than by a person; an implementation that needs less supervision to stay on the agreed path.
 - **Regressing looks like:** an agent improvising beyond what was agreed; verification that checks only that the code works, not that it is what was agreed; a capability that improves code in general but not its fidelity to the agreement.

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -55,4 +55,4 @@ The method is a single path: intent → confirmed understanding → implementati
 - **Advancing looks like:** fewer commands doing the same work; an integration in place of an owned capability; a proven experiment folded into core and its predecessor removed.
 - **Regressing looks like:** a capability that sits outside the path, however useful; two ways to do the same step kept alive indefinitely; a feature that serves the host tool rather than the method.
 
-Serves principles 8 and 9.
+Serves principles 8 and 10.

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -1,6 +1,6 @@
 # Direction
 
-The directions `awos` always moves in. None of them is ever finished, since each is something the framework can always be more of, and none carries a date or a priority; those belong to the roadmap. Each follows from the principles in [Philosophy](philosophy.md).
+The directions `awos` always moves in. None of them is ever finished, since each is something the framework can always be more of, and none carries a date or a priority; those belong to the roadmap. When two directions pull against each other, toward agreement wins: the confirmation moment is what `awos` exists for, and the other four directions serve it. Each direction follows from the principles in [Philosophy](philosophy.md); principle 10 (one host) is a standing constraint on all of them rather than a direction of its own.
 
 ## Toward agreement
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -26,27 +26,31 @@ There is always a moment where the human can see what the agent understood and s
 
 Implementation is judged by how faithfully it realizes the confirmed understanding, and verification checks the result against that agreement rather than only whether the code works. Implementation improvements belong in `awos` when they raise that fidelity or make deviation from the agreement visible sooner; improvements to code quality in general belong to the host tool.
 
-### 5. Write for the reader
+### 5. `awos` verifies its own work
+
+Work is done when the checks pass, not when the agent says so — and `awos` runs the checks itself. This is only possible when acceptance criteria are concrete enough for `awos` to check each one; a criterion only a person can judge is marked as such, and `awos` brings them the evidence. A change that makes the work harder to verify is not an improvement.
+
+### 6. Write for the reader
 
 Agents and humans need information presented differently. Keep the structured source useful for agents, and derive focused human-facing views from it whenever someone needs to review or make a decision.
 
-### 6. Make the missing parts reviewable
+### 7. Make the missing parts reviewable
 
 What is written in a specification is easy to review. What is missing is much harder to notice, even when it is essential. `awos` looks for gaps in requirements and acceptance criteria, makes every inference explicit, and shows the evidence behind it. When there is not enough evidence, it raises an open question instead of guessing.
 
-### 7. The project remembers
+### 8. The project remembers
 
 Knowledge produced by a change outlives the change. A new piece of work starts from what the product already is, not from a blank page or a single line in a backlog. The method keeps that knowledge current itself rather than asking people to.
 
-### 8. `awos` owns one path
+### 9. `awos` owns one path
 
 Intent → confirmed understanding → implementation → verification. Everything around that path — backlog, branching, code review, deployment, tickets, team tooling — is something `awos` plugs into, never something it provides.
 
-### 9. `awos` speaks one host, natively
+### 10. `awos` speaks one host, natively
 
 `awos` is built for Claude Code, by design. The method depends on what the host actually provides — subagents, structured questions to the human, hooks, skills, plugins — and it uses those primitives directly, with no abstraction layer between them and the prompts. This is a quality decision, not a convenience: every layer meant to make `awos` portable would flatten the host's capabilities to the lowest common denominator and make the behavior of the method harder to test and tune. One host means one set of behaviors to verify against, and the full depth of that host's tools available to the method.
 
-### 10. `awos` is for work worth specifying
+### 11. `awos` is for work worth specifying
 
 Reaching agreement before building takes time. Use `awos` when that effort costs less than getting the result wrong. For exploration, prototypes, hotfixes, and small edits, the agent's normal planning is usually enough.
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -26,13 +26,13 @@ There is always a moment where the human can see what the agent understood and s
 
 Implementation is judged by how faithfully it realizes the confirmed understanding, and verification checks the result against that agreement rather than only whether the code works. Implementation improvements belong in `awos` when they raise that fidelity or make deviation from the agreement visible sooner; improvements to code quality in general belong to the host tool.
 
-### 5. Every artifact has one reader
+### 5. Write for the reader
 
-Agents read structured truth. Humans read what they need to decide. Nothing serves both: when a document tries, it fails the human, and the human stops reading. Human-facing views are derived from the agent-facing source, never maintained by hand, and exist to enable a decision.
+Agents and humans need information presented differently. Keep the structured source useful for agents, and derive focused human-facing views from it whenever someone needs to review or make a decision.
 
-### 6. What is unsaid is part of the spec
+### 6. Make the missing parts reviewable
 
-Assumptions, decisions made without being asked, and things left unchanged are made visible. Rework comes from omissions, and omissions are what a human cannot hold in their head unaided while reviewing a long list of requirements.
+What is written in a specification is easy to review. What is missing is much harder to notice, even when it is essential. `awos` looks for gaps in requirements and acceptance criteria, makes every inference explicit, and shows the evidence behind it. When there is not enough evidence, it raises an open question instead of guessing.
 
 ### 7. The project remembers
 
@@ -48,7 +48,7 @@ Intent → confirmed understanding → implementation → verification. Everythi
 
 ### 10. `awos` is for work worth specifying
 
-When the cost of being wrong is lower than the cost of agreeing first, `awos` is the wrong tool, and it says so. Exploration, prototypes, hotfixes, and small edits have their own tools.
+Reaching agreement before building takes time. Use `awos` when that effort costs less than getting the result wrong. For exploration, prototypes, hotfixes, and small edits, the agent's normal planning is usually enough.
 
 ## What `awos` Is Not
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -26,9 +26,9 @@ There is always a moment where the human can see what the agent understood and s
 
 Implementation is judged by how faithfully it realizes the confirmed understanding, and verification checks the result against that agreement rather than only whether the code works. Implementation improvements belong in `awos` when they raise that fidelity or make deviation from the agreement visible sooner; improvements to code quality in general belong to the host tool.
 
-### 5. `awos` verifies its own work
+### 5. `awos` checks its own work
 
-Work is done when the checks pass, not when the agent says so — and `awos` runs the checks itself. This is only possible when acceptance criteria are concrete enough for `awos` to check each one; a criterion only a person can judge is marked as such, and `awos` brings them the evidence. A change that makes the work harder to verify is not an improvement.
+`awos` does not consider work done until it has made sure of it itself. Noticing that something is incomplete, wrong, or missing is `awos`'s job, not the human's. Where it cannot make sure, it says so. Quality and the ability to check it advance together — more checks do not make the work good, and good work is not done until it can be checked. A change to `awos` that trades one for the other is not an improvement.
 
 ### 6. Write for the reader
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -6,33 +6,33 @@ What `awos` is, what it is not, and the principles it is built on.
 
 **`awos` is a method for turning intent into working software with agents, where the human decides and the agent builds.**
 
-The product of `awos` is not documents. It is _agreement_ — a confirmed, shared understanding between the human and the agent about what is being built and why. Documents are how that agreement is stored and transported; they are never the goal.
+The product of `awos` is agreement: a confirmed, shared understanding between the human and the agent about what is being built and why. Documents are how that agreement is stored and transported.
 
 ## Principles
 
-### 1. Judge by outcome, not by instruction
+### 1. Judge by outcome
 
 The measure of `awos` is whether what ships is what was wanted, the first time. Better documents, better prompts, and better process are only means. Anything that makes them richer without moving that outcome is waste.
 
 ### 2. Intent is gathered, then confirmed
 
-The human is the authority on intent, but not necessarily its only source. The person at the keyboard may hold part of the picture; the rest lives in code, tickets, past decisions, and other people — and sometimes it has not been decided yet. `awos` goes and finds the missing parts and brings them back to the human to confirm. It never fills a gap by guessing: what cannot be found is surfaced as an open question, not quietly resolved.
+The human is the authority on intent, but not necessarily its only source. The person at the keyboard may hold part of the picture; the rest lives in code, tickets, past decisions, and other people, and sometimes it has not been decided yet. `awos` goes and finds the missing parts and brings them back to the human to confirm. It never fills a gap by guessing: what cannot be found is surfaced as an open question.
 
 ### 3. Understanding is confirmed before anything is built
 
-There is always a moment where the human can see what the agent understood and say "yes, that" or "no, not that." It comes before code, where a misunderstanding is cheapest to fix. This moment is the center of the method; everything else exists to make it possible.
+There is always a moment where the human can see what the agent understood and say "yes, that" or "no, not that." It comes before code, where a misunderstanding is cheapest to fix. Everything else in the method exists to make this moment possible.
 
 ### 4. The agreement is the contract for the build
 
-Implementation is judged by how faithfully it realizes the confirmed understanding, and verification checks the result against that agreement — not merely that the code works. Implementation improvements belong in `awos` when they raise that fidelity or make deviation from the agreement visible sooner; improvements to code quality in general belong to the host tool.
+Implementation is judged by how faithfully it realizes the confirmed understanding, and verification checks the result against that agreement rather than only whether the code works. Implementation improvements belong in `awos` when they raise that fidelity or make deviation from the agreement visible sooner; improvements to code quality in general belong to the host tool.
 
 ### 5. Every artifact has one reader
 
-Agents read structured truth. Humans read what they need in order to decide. Nothing serves both: when a document tries, it fails the human, and the human stops reading. Human-facing views are derived from the agent-facing source, never maintained by hand, and exist to enable a decision rather than to inform.
+Agents read structured truth. Humans read what they need to decide. Nothing serves both: when a document tries, it fails the human, and the human stops reading. Human-facing views are derived from the agent-facing source, never maintained by hand, and exist to enable a decision.
 
 ### 6. What is unsaid is part of the spec
 
-Assumptions, decisions made without being asked, and things left unchanged are made visible. Omissions, not statements, are where rework comes from — and they are exactly what a human cannot hold in their head unaided while reviewing a long list of requirements.
+Assumptions, decisions made without being asked, and things left unchanged are made visible. Rework comes from omissions, and omissions are what a human cannot hold in their head unaided while reviewing a long list of requirements.
 
 ### 7. The project remembers
 
@@ -44,7 +44,7 @@ Intent → confirmed understanding → implementation → verification. Everythi
 
 ### 9. `awos` is for work worth specifying
 
-When the cost of being wrong is lower than the cost of agreeing first, `awos` is the wrong tool, and it says so instead of shrinking to fit. Exploration, prototypes, hotfixes, and small edits have their own tools.
+When the cost of being wrong is lower than the cost of agreeing first, `awos` is the wrong tool, and it says so. Exploration, prototypes, hotfixes, and small edits have their own tools.
 
 ## What `awos` Is Not
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -42,7 +42,11 @@ Knowledge produced by a change outlives the change. A new piece of work starts f
 
 Intent → confirmed understanding → implementation → verification. Everything around that path — backlog, branching, code review, deployment, tickets, team tooling — is something `awos` plugs into, never something it provides.
 
-### 9. `awos` is for work worth specifying
+### 9. `awos` speaks one host, natively
+
+`awos` is built for Claude Code, by design. The method depends on what the host actually provides — subagents, structured questions to the human, hooks, skills, plugins — and it uses those primitives directly, with no abstraction layer between them and the prompts. This is a quality decision, not a convenience: every layer meant to make `awos` portable would flatten the host's capabilities to the lowest common denominator and make the behavior of the method harder to test and tune. One host means one set of behaviors to verify against, and the full depth of that host's tools available to the method.
+
+### 10. `awos` is for work worth specifying
 
 When the cost of being wrong is lower than the cost of agreeing first, `awos` is the wrong tool, and it says so. Exploration, prototypes, hotfixes, and small edits have their own tools.
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,58 @@
+# The `awos` Philosophy
+
+What `awos` is, what it is not, and the principles it is built on.
+
+## What `awos` Is
+
+**`awos` is a method for turning intent into working software with agents, where the human decides and the agent builds.**
+
+The product of `awos` is not documents. It is _agreement_ — a confirmed, shared understanding between the human and the agent about what is being built and why. Documents are how that agreement is stored and transported; they are never the goal.
+
+## Principles
+
+### 1. Judge by outcome, not by instruction
+
+The measure of `awos` is whether what ships is what was wanted, the first time. Better documents, better prompts, and better process are only means. Anything that makes them richer without moving that outcome is waste.
+
+### 2. Intent is gathered, then confirmed
+
+The human is the authority on intent, but not necessarily its only source. The person at the keyboard may hold part of the picture; the rest lives in code, tickets, past decisions, and other people — and sometimes it has not been decided yet. `awos` goes and finds the missing parts and brings them back to the human to confirm. It never fills a gap by guessing: what cannot be found is surfaced as an open question, not quietly resolved.
+
+### 3. Understanding is confirmed before anything is built
+
+There is always a moment where the human can see what the agent understood and say "yes, that" or "no, not that." It comes before code, where a misunderstanding is cheapest to fix. This moment is the center of the method; everything else exists to make it possible.
+
+### 4. The agreement is the contract for the build
+
+Implementation is judged by how faithfully it realizes the confirmed understanding, and verification checks the result against that agreement — not merely that the code works. Implementation improvements belong in `awos` when they raise that fidelity or make deviation from the agreement visible sooner; improvements to code quality in general belong to the host tool.
+
+### 5. Every artifact has one reader
+
+Agents read structured truth. Humans read what they need in order to decide. Nothing serves both: when a document tries, it fails the human, and the human stops reading. Human-facing views are derived from the agent-facing source, never maintained by hand, and exist to enable a decision rather than to inform.
+
+### 6. What is unsaid is part of the spec
+
+Assumptions, decisions made without being asked, and things left unchanged are made visible. Omissions, not statements, are where rework comes from — and they are exactly what a human cannot hold in their head unaided while reviewing a long list of requirements.
+
+### 7. The project remembers
+
+Knowledge produced by a change outlives the change. A new piece of work starts from what the product already is, not from a blank page or a single line in a backlog. The method keeps that knowledge current itself rather than asking people to.
+
+### 8. `awos` owns one path
+
+Intent → confirmed understanding → implementation → verification. Everything around that path — backlog, branching, code review, deployment, tickets, team tooling — is something `awos` plugs into, never something it provides.
+
+### 9. `awos` is for work worth specifying
+
+When the cost of being wrong is lower than the cost of agreeing first, `awos` is the wrong tool, and it says so instead of shrinking to fit. Exploration, prototypes, hotfixes, and small edits have their own tools.
+
+## What `awos` Is Not
+
+- A Claude Code distribution or a bundle of best practices.
+- A delivery process — git flow, review gates, release management.
+- A planning or backlog tool.
+- A code-quality or engineering-metrics tool.
+- A way to discover what to build.
+- A document generator.
+
+Where these principles lead is in [Direction](direction.md); the reasoning behind them is in [Why `awos` Works](rationale.md).

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -1,43 +1,39 @@
-# The `awos` Philosophy: Why It Works
+# Why `awos` Works
 
-In the new era of AI-powered development, it's tempting to ask an LLM to "just write the code." However, this often leads to poor results. This document explains the thinking behind the **`awos`** framework and why its structured process is the key to building high-quality software with AI agents.
+What `awos` is — and is not — is defined in [Philosophy](philosophy.md); where it is heading, in [Direction](direction.md). This is the reasoning behind both.
 
-## The Problem: LLMs Are Like Confused Interns
+## A Senior Engineer on Their First Day
 
-Imagine you have a new, very smart intern. If you tell them, "build a login feature," without any other information, what will you get? They will build _a_ login feature, but it probably won't be the _right_ one for your product.
+A modern coding agent is not a junior. It is a very senior engineer on their first day at your company: there is nothing it cannot build, no stack it does not know, no pattern it has not seen. What it lacks is exactly what any senior lacks on day one — it does not know how things are done here, and it does not know what the thing you are asking for actually is.
 
-LLMs are the same. They are incredibly powerful, but they start with zero knowledge of your project. Without complete, well-organized information about the problem, the desired solution, and the technical environment, an LLM will produce generic, incorrect code. **The `awos` framework is designed to turn a confused intern into an expert team member by giving it the context it needs.**
+That second gap is the dangerous one, and seniority is what makes it dangerous. A junior who does not understand a task asks. A senior who does not understand a task makes a reasonable assumption and keeps going, confidently, and you find out what they assumed at review. The agent behaves the same way: given an incomplete picture, it fills the gaps with something plausible and builds it well.
 
-## Your New Job: Making Your Product the Next "Tetris"
+## Context Engineering Solved the First Half
 
-LLM agents are brilliant at creating things they already understand deeply. Ask one to make a game like Tetris, and it will do a great job. Why? Because the concept of Tetris is part of its vast, pre-existing knowledge.
+"How things are done here" is a solved problem, and it is not what `awos` is for. Well-kept instruction files, architecture notes, and the codebase itself give the agent the conventions, the stack, and the shape of the system, and current models read them well. Teams that do this get code that fits.
 
-However, the LLM knows nothing about _your_ business, _your_ product, or _your_ users.
+They still get rework. Our own measurements show that teams that have adopted agent-driven development most heavily also show the highest rework rates. The code fits the codebase; it does not fit what was wanted.
 
-The most essential work for a modern software team is to provide this context to the AI agents. Your job is to carefully explain every piece of your project until the LLM "knows" your product as well as it knows Tetris. **`awos` provides the tools to teach the AI the rules of your unique game.**
+## The Half It Did Not Solve
 
-## How We Teach: The Power of Specifications
+The missing half is intent: what the feature is, why it exists, what it must and must not do. This is harder than it sounds, because that knowledge usually does not live in one place — and often not in the head of the person at the keyboard. They were handed a ticket; the reasons stayed with a product manager, a customer conversation, a decision made months ago, or a behavior of the existing system that everyone assumes and nobody wrote down.
 
-The primary "lesson plan" for teaching an LLM is a good specification.
+Nothing in a codebase can supply this. So the agent supplies it itself — plausibly, silently, and wrong in ways nobody notices until the feature exists. That is where rework comes from. Not from bad code, but from a confident answer to a question nobody actually asked.
 
-A proper specification doesn't just list features. It clearly explains _what_ a feature must do, _why_ it is needed, and _who_ it is for. This understanding of the ultimate goal is essential. When everyone (including the AI agent) is aligned on the goal, we can build exactly what is expected on the first try.
+## Making It as Known as Tetris
 
-This is the key to true efficiency. The power of LLMs is not just writing code fast; it's writing the _correct_ code fast. **A good specification ensures the AI's speed is applied in the right direction.**
+Ask an agent to build Tetris and it builds a good one, because it knows what Tetris is — every rule, every edge case, what "done" looks like — before it writes a line. It knows this not because someone briefed it, but because the game is fully known.
 
-## A Complete Story: The `awos` Vertical Structure
+Your feature has to become that known. Not the codebase — the feature: what it is, why, and where it stops. That knowledge is not something one person dictates; it is assembled from the ticket, the code, the past decisions, and the people who hold the pieces, and it is not complete until the gaps are visible and someone has said what goes in them.
 
-A product is more than just a collection of features; it has a broader context of business goals and technical rules. Each specification exists for a reason that is part of a bigger story.
+## Why Agreement, Not Documents
 
-That is why **`awos`** is built on a vertical structure, moving from a high-level vision down to the smallest implementation detail. Think of it like using a map with different zoom levels.
+`awos` follows one path: describe the change, confirm the agent understood it, build it, and check the result against what was agreed.
 
-1. **Product Definition**: The 10,000-foot view of the entire world.
+The middle step is the one that matters. A specification nobody confirmed is not alignment; it is a well-formatted guess. What produces a feature that ships right the first time is the moment where a person sees what the agent understood — including what it assumed and what it left out — and says "yes, that" or "no, not that," before any code exists. The specification is where that agreement is stored. The confirmation is what makes it real.
 
-2. **Roadmap**: Zooming in on the country we will visit this year.
+From there the roles are clear: the human decides, the agent builds, and the build is judged by how faithfully it honors the agreement rather than by whether the code merely works.
 
-3. **Functional Spec**: Zooming in on the specific city we are exploring today.
+## When Not to Use It
 
-4. **Technical Spec**: The detailed street map of that city.
-
-5. **Task List**: The turn-by-turn directions for our walk.
-
-Each step provides the right information at the right level of detail. By following this process, you tell a complete and coherent story to the AI agents, ensuring they have the full context they need to build your vision into reality.
+Agreeing first costs something. `awos` is for changes where being wrong costs more than that — a feature that touches several parts of the system, a behavior other people depend on, work that will be hard to undo. A prototype, a hotfix, or a small edit does not need it; the agent's own planning handles those well, and `awos` does not try to fit.

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -1,39 +1,39 @@
 # Why `awos` Works
 
-What `awos` is — and is not — is defined in [Philosophy](philosophy.md); where it is heading, in [Direction](direction.md). This is the reasoning behind both.
+What `awos` is, and is not, is defined in [Philosophy](philosophy.md); where it is heading, in [Direction](direction.md). This is the reasoning behind both.
 
 ## A Senior Engineer on Their First Day
 
-A modern coding agent is not a junior. It is a very senior engineer on their first day at your company: there is nothing it cannot build, no stack it does not know, no pattern it has not seen. What it lacks is exactly what any senior lacks on day one — it does not know how things are done here, and it does not know what the thing you are asking for actually is.
+A modern coding agent is a very senior engineer on their first day at your company. There is no stack it does not know and no pattern it has not seen. What it lacks is what any senior lacks on day one: it does not know how things are done here, and it does not know what the thing you are asking for is.
 
-That second gap is the dangerous one, and seniority is what makes it dangerous. A junior who does not understand a task asks. A senior who does not understand a task makes a reasonable assumption and keeps going, confidently, and you find out what they assumed at review. The agent behaves the same way: given an incomplete picture, it fills the gaps with something plausible and builds it well.
+The second gap is the dangerous one, and seniority is what makes it dangerous. A junior who does not understand a task asks. A senior who does not understand a task makes a reasonable assumption, keeps going, and you find out what they assumed at review. The agent does the same: given an incomplete picture, it fills the gaps with something plausible and builds it well.
 
 ## Context Engineering Solved the First Half
 
 "How things are done here" is a solved problem, and it is not what `awos` is for. Well-kept instruction files, architecture notes, and the codebase itself give the agent the conventions, the stack, and the shape of the system, and current models read them well. Teams that do this get code that fits.
 
-They still get rework. Our own measurements show that teams that have adopted agent-driven development most heavily also show the highest rework rates. The code fits the codebase; it does not fit what was wanted.
+They still get rework. We measured this across our own teams: the ones that adopted agent-driven development most heavily also had the highest rework rates. The code fits the codebase and misses what was wanted.
 
 ## The Half It Did Not Solve
 
-The missing half is intent: what the feature is, why it exists, what it must and must not do. This is harder than it sounds, because that knowledge usually does not live in one place — and often not in the head of the person at the keyboard. They were handed a ticket; the reasons stayed with a product manager, a customer conversation, a decision made months ago, or a behavior of the existing system that everyone assumes and nobody wrote down.
+The missing half is intent: what the feature is, why it exists, what it must and must not do. That knowledge usually does not live in one place, and often not in the head of the person at the keyboard. They were handed a ticket; the reasons stayed with a product manager, a customer conversation, a decision made months ago, or a behavior of the existing system that everyone assumes and nobody wrote down.
 
-Nothing in a codebase can supply this. So the agent supplies it itself — plausibly, silently, and wrong in ways nobody notices until the feature exists. That is where rework comes from. Not from bad code, but from a confident answer to a question nobody actually asked.
+Nothing in a codebase can supply this, so the agent supplies it itself: plausibly, silently, and wrong in ways nobody notices until the feature exists. Rework comes from a confident answer to a question nobody asked.
 
 ## Making It as Known as Tetris
 
-Ask an agent to build Tetris and it builds a good one, because it knows what Tetris is — every rule, every edge case, what "done" looks like — before it writes a line. It knows this not because someone briefed it, but because the game is fully known.
+Ask an agent to build Tetris and it builds a good one, because it knows what Tetris is before it writes a line: every rule, every edge case, what "done" looks like. Nobody briefed it; the game is fully known.
 
-Your feature has to become that known. Not the codebase — the feature: what it is, why, and where it stops. That knowledge is not something one person dictates; it is assembled from the ticket, the code, the past decisions, and the people who hold the pieces, and it is not complete until the gaps are visible and someone has said what goes in them.
+The feature, not the codebase, has to become that known: what it is, why, and where it stops. No one person can dictate that knowledge. It is assembled from the ticket, the code, the past decisions, and the people who hold the pieces, and it is not complete until the gaps are visible and someone has said what goes in them.
 
-## Why Agreement, Not Documents
+## Why Agreement
 
 `awos` follows one path: describe the change, confirm the agent understood it, build it, and check the result against what was agreed.
 
-The middle step is the one that matters. A specification nobody confirmed is not alignment; it is a well-formatted guess. What produces a feature that ships right the first time is the moment where a person sees what the agent understood — including what it assumed and what it left out — and says "yes, that" or "no, not that," before any code exists. The specification is where that agreement is stored. The confirmation is what makes it real.
+A specification nobody confirmed is a well-formatted guess. What produces a feature that ships right the first time is the moment where a person sees what the agent understood, including what it assumed and what it left out, and says "yes, that" or "no, not that" before any code exists. The specification is where that agreement is stored.
 
-From there the roles are clear: the human decides, the agent builds, and the build is judged by how faithfully it honors the agreement rather than by whether the code merely works.
+From there, the human decides, the agent builds, and the build is judged by how faithfully it honors the agreement rather than by whether the code works.
 
 ## When Not to Use It
 
-Agreeing first costs something. `awos` is for changes where being wrong costs more than that — a feature that touches several parts of the system, a behavior other people depend on, work that will be hard to undo. A prototype, a hotfix, or a small edit does not need it; the agent's own planning handles those well, and `awos` does not try to fit.
+Agreeing first costs time, so `awos` is for changes where being wrong costs more: a feature that touches several parts of the system, a behavior other people depend on, work that will be hard to undo. A prototype, a hotfix, or a small edit does not need it; the agent's own planning handles those well.


### PR DESCRIPTION
## Summary

Establishes the foundation for the next year of awos development — three documents that answer *why does it work*, *what is it*, and *where is it going*.

- **`docs/philosophy.md`** (new) — what awos is and is not, and eleven principles. Retires the founding assumption that the person at the keyboard knows what to build. States that the product of awos is *agreement* — a confirmed shared understanding between human and agent — not documents; that intent is gathered from wherever it lives and confirmed by the human, never filled by guessing; and that the agreement is the contract the build is judged against.
- **`docs/direction.md`** (new) — five directions awos always moves in: toward agreement, discovery, memory, fidelity, and a smaller surface. Each states what advancing and regressing look like. Deliberately no dates, priorities, or feature lists — those belong to the roadmap.
- **`docs/rationale.md`** (rewritten) — the "why it works" explanation, for a reader who already knows context engineering. The "confused intern" becomes a very senior engineer on their first day (capable of anything, but assumes instead of asking); Tetris is retargeted at making the *feature* known rather than the codebase; the document-enumeration "Complete Story" section is dropped.
- `README.md` philosophy section and `CONTRIBUTING.md` docs tree link all three.

## Also in this PR

- The README tip "Don't hesitate to delete specs after implementation" is removed — it contradicted principle 8 (*the project remembers*). Note the flow doesn't yet keep specs current itself, so pruning stale specs remains a manual judgment call until "toward memory" ships something; the command docs may deserve a transitional note (tracked separately as a known gap).

## Verification

- `npx prettier --check` passes on all touched files.
- `npm run test:lint` passes (no prompt files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfCeZDPfTF3fyxPXbPNYcj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added philosophy and direction guides covering core principles, guiding questions, and recommended practices.
  * Rewrote the rationale documentation with updated explanations of context, intent, agreement, and the describe–confirm–build–check workflow.
  * Updated the README with revised philosophy content and links to related documentation.
  * Updated contribution guidance to reflect the expanded documentation structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
