### PR TITLE
docs: one-host principle and drop the spec-deletion tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ These commands establish your project's foundation. Run them once at the start, 
 
 Once your foundation is set, iterate through this cycle for each feature on your roadmap. These commands are designed to be run repeatedly — once per feature.
 
-> **Tip**: Don't hesitate to delete specs after implementation. Completed specs can become outdated and confuse the AI. Your code documentation is the source of truth.
-
 | Command           | What it does                                                                      | Docs                                  |
 | ----------------- | --------------------------------------------------------------------------------- | ------------------------------------- |
 | `/awos:spec`      | Creates the Functional Spec — what the feature does for the user.                 | [Details](docs/commands/spec.md)      |

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -55,4 +55,4 @@ The method is a single path: intent → confirmed understanding → implementati
 - **Advancing looks like:** fewer commands doing the same work; an integration in place of an owned capability; a proven experiment folded into core and its predecessor removed.
 - **Regressing looks like:** a capability that sits outside the path, however useful; two ways to do the same step kept alive indefinitely; a feature that serves the host tool rather than the method.
 
-Serves principles 8 and 9.
+Serves principles 8 and 10.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -42,7 +42,11 @@ Knowledge produced by a change outlives the change. A new piece of work starts f
 
 Intent → confirmed understanding → implementation → verification. Everything around that path — backlog, branching, code review, deployment, tickets, team tooling — is something `awos` plugs into, never something it provides.
 
-### 9. `awos` is for work worth specifying
+### 9. `awos` speaks one host, natively
+
+`awos` is built for Claude Code, by design. The method depends on what the host actually provides — subagents, structured questions to the human, hooks, skills, plugins — and it uses those primitives directly, with no abstraction layer between them and the prompts. This is a quality decision, not a convenience: every layer meant to make `awos` portable would flatten the host's capabilities to the lowest common denominator and make the behavior of the method harder to test and tune. One host means one set of behaviors to verify against, and the full depth of that host's tools available to the method.
+
+### 10. `awos` is for work worth specifying
 
 When the cost of being wrong is lower than the cost of agreeing first, `awos` is the wrong tool, and it says so. Exploration, prototypes, hotfixes, and small edits have their own tools.
 


### PR DESCRIPTION
## Summary

Follow-up to #194, targeting its branch so it lands as part of the same docs set.

- **`docs/philosophy.md`** — new principle 9, *`awos` speaks one host, natively*: `awos` is built for Claude Code by design and uses the host's primitives (subagents, structured questions, hooks, skills, plugins) directly, with no abstraction layer. Stated as a quality decision: a portability layer would flatten the host's capabilities to the lowest common denominator and make the method harder to test and tune. The former principle 9 (*work worth specifying*) becomes 10.
- **`docs/direction.md`** — *Toward a smaller surface* now reads "Serves principles 8 and 10" (renumbering only).
- **`README.md`** — removed the "Don't hesitate to delete specs after implementation" tip, which #194 flagged as contradicting principle 7. It also contradicts the flow itself: `/awos:spec` has an Update Mode that amends existing specs, and the generated `/fix-bug` flow's `amend-spec` stage depends on them.

## Verification

- `npx prettier --check` passes on touched files.
- `npm run test:lint` passes (159/159).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
