### PR TITLE
docs: add the self-verification principle

### DIFF
--- a/docs/direction.md
+++ b/docs/direction.md
@@ -11,7 +11,7 @@ The directions `awos` always moves in. None of them is ever finished, since each
 - **Advancing looks like:** a misunderstanding surfaces earlier than it did before; the time to a confident yes or no goes down; something a person had to hold in their head is now something they can read.
 - **Regressing looks like:** more content to review without more decisions to make; a check that happens after implementation instead of before; a confirmation that is a formality because nobody could evaluate it.
 
-Serves principles 1, 3, 5, and 6.
+Serves principles 1, 3, 6, and 7.
 
 ## Toward discovery
 
@@ -22,7 +22,7 @@ Intent is scattered across code, tickets, documentation, past decisions, and oth
 - **Advancing looks like:** a source of intent that `awos` reads on its own; a question the human no longer has to be asked; a gap that is surfaced as unknown instead of silently filled.
 - **Regressing looks like:** a longer interview; a file the human must maintain so that the agent can read it; an agent that resolves ambiguity by picking the plausible option.
 
-Serves principle 2; supports 3 and 6.
+Serves principle 2; supports 3 and 7.
 
 ## Toward memory
 
@@ -33,7 +33,7 @@ A project that remembers what it is makes every subsequent change easier to spec
 - **Advancing looks like:** knowledge produced by a change is retained by the flow itself; a later spec reads what an earlier one established; the product's current behavior is available to the agent, not only its history of intentions.
 - **Regressing looks like:** artifacts treated as disposable once implemented; upkeep of knowledge delegated to people; a document nothing in the flow keeps current.
 
-Serves principle 7; deepens 6.
+Serves principle 8; deepens 7.
 
 ## Toward fidelity
 
@@ -44,7 +44,7 @@ Agreement is only worth reaching if the build honors it. `awos` moves toward imp
 - **Advancing looks like:** fewer corrections between implementation and verification; a deviation from the agreement caught by the flow rather than by a person; an implementation that needs less supervision to stay on the agreed path.
 - **Regressing looks like:** an agent improvising beyond what was agreed; verification that checks only that the code works, not that it is what was agreed; a capability that improves code in general but not its fidelity to the agreement.
 
-Serves principles 1 and 4.
+Serves principles 1, 4, and 5.
 
 ## Toward a smaller surface
 
@@ -55,4 +55,4 @@ The method is a single path: intent → confirmed understanding → implementati
 - **Advancing looks like:** fewer commands doing the same work; an integration in place of an owned capability; a proven experiment folded into core and its predecessor removed.
 - **Regressing looks like:** a capability that sits outside the path, however useful; two ways to do the same step kept alive indefinitely; a feature that serves the host tool rather than the method.
 
-Serves principles 8 and 10.
+Serves principles 9 and 11.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -26,27 +26,31 @@ There is always a moment where the human can see what the agent understood and s
 
 Implementation is judged by how faithfully it realizes the confirmed understanding, and verification checks the result against that agreement rather than only whether the code works. Implementation improvements belong in `awos` when they raise that fidelity or make deviation from the agreement visible sooner; improvements to code quality in general belong to the host tool.
 
-### 5. Write for the reader
+### 5. `awos` verifies its own work
+
+Work is done when the checks pass, not when the agent says so — and `awos` runs the checks itself. This is only possible when acceptance criteria are concrete enough for `awos` to check each one; a criterion only a person can judge is marked as such, and `awos` brings them the evidence. A change that makes the work harder to verify is not an improvement.
+
+### 6. Write for the reader
 
 Agents and humans need information presented differently. Keep the structured source useful for agents, and derive focused human-facing views from it whenever someone needs to review or make a decision.
 
-### 6. Make the missing parts reviewable
+### 7. Make the missing parts reviewable
 
 What is written in a specification is easy to review. What is missing is much harder to notice, even when it is essential. `awos` looks for gaps in requirements and acceptance criteria, makes every inference explicit, and shows the evidence behind it. When there is not enough evidence, it raises an open question instead of guessing.
 
-### 7. The project remembers
+### 8. The project remembers
 
 Knowledge produced by a change outlives the change. A new piece of work starts from what the product already is, not from a blank page or a single line in a backlog. The method keeps that knowledge current itself rather than asking people to.
 
-### 8. `awos` owns one path
+### 9. `awos` owns one path
 
 Intent → confirmed understanding → implementation → verification. Everything around that path — backlog, branching, code review, deployment, tickets, team tooling — is something `awos` plugs into, never something it provides.
 
-### 9. `awos` speaks one host, natively
+### 10. `awos` speaks one host, natively
 
 `awos` is built for Claude Code, by design. The method depends on what the host actually provides — subagents, structured questions to the human, hooks, skills, plugins — and it uses those primitives directly, with no abstraction layer between them and the prompts. This is a quality decision, not a convenience: every layer meant to make `awos` portable would flatten the host's capabilities to the lowest common denominator and make the behavior of the method harder to test and tune. One host means one set of behaviors to verify against, and the full depth of that host's tools available to the method.
 
-### 10. `awos` is for work worth specifying
+### 11. `awos` is for work worth specifying
 
 Reaching agreement before building takes time. Use `awos` when that effort costs less than getting the result wrong. For exploration, prototypes, hotfixes, and small edits, the agent's normal planning is usually enough.
 


### PR DESCRIPTION
## Summary

Follow-up to #194, targeting its branch.

- **`docs/philosophy.md`** — new principle 5, *`awos` verifies its own work*: work is done when the checks pass, not when the agent says so, and `awos` runs the checks itself; acceptance criteria are concrete enough for `awos` to check each one (a criterion only a person can judge is marked as such, with the evidence brought to them); a change that makes the work harder to verify is not an improvement. Placed after principle 4, since it says *who* verifies where 4 says *against what*. Former principles 5–10 become 6–11.
- **`docs/direction.md`** — principle references renumbered; *Toward fidelity* now also cites the new principle 5 (a deviation caught by the flow rather than by a person is exactly self-verification).

## Verification

- `npx prettier --check docs/` passes.
- `npm run test:lint` passes (159/159).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
